### PR TITLE
Fix dash SIGFPE crash

### DIFF
--- a/libavformat/dashenc.c
+++ b/libavformat/dashenc.c
@@ -1909,9 +1909,10 @@ static int dash_flush(AVFormatContext *s, int final, int stream)
 
         if (!os->bit_rate) {
             // calculate average bitrate of first segment
-            int64_t bitrate = (int64_t) range_length * 8 * AV_TIME_BASE / av_rescale_q(os->max_pts - os->start_pts,
-                                                                                       st->time_base,
-                                                                                       AV_TIME_BASE_Q);
+            int64_t rescale = av_rescale_q(os->max_pts - os->start_pts, st->time_base, AV_TIME_BASE_Q);
+            int64_t bitrate = 0;
+            if (rescale != 0)
+                bitrate = range_length * 8 * AV_TIME_BASE / rescale;
             if (bitrate >= 0)
                 os->bit_rate = bitrate;
         }


### PR DESCRIPTION
issue: https://github.com/qluvio/avpipe/issues/5
- Avoid divide by zero on very special case when generating DASH ABR segments