### PR TITLE
Rewrite `build.sh` for readability and safety

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,9 +4,11 @@ ffmpeg_proj_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DIST=${ffmpeg_proj_dir}/"dist"
 
 if [ ! -d ${DIST} ]; then
-    mkdir ${DIST}
-    echo "CREATED" ${DIST}
+    mkdir -p ${DIST}
+    echo "CREATED ${DIST}"
 fi
+
+echo "DIST=${DIST}"
 
 CONFIGURE_TO_USE="./configure"
 
@@ -84,7 +86,10 @@ elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW64_NT" ]; then
     exit 1
 fi
 
-${CONFIGURE_TO_USE} ${command_options[@]}
+(
+    cd ${ffmpeg_proj_dir}
+    ${CONFIGURE_TO_USE} ${command_options[@]}
+)
 
 NPROCS=$(getconf _NPROCESSORS_ONLN)
 ELUVIO_BUILD_THREAD_COUNT=${ELUVIO_BUILD_THREAD_COUNT:-"-j${NPROCS}"}

--- a/build.sh
+++ b/build.sh
@@ -1,47 +1,90 @@
-DIST=$PWD/"dist"
+#!/bin/bash
+ffmpeg_proj_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-if [ ! -d $DIST ]; then
-    mkdir $DIST
-    echo "CREATED" $DIST
+DIST=${ffmpeg_proj_dir}/"dist"
+
+if [ ! -d ${DIST} ]; then
+    mkdir ${DIST}
+    echo "CREATED" ${DIST}
 fi
 
 CONFIGURE_TO_USE="./configure"
 
+command_options=(
+    --prefix=${DIST}
+    --enable-libfreetype
+    --enable-libfribidi
+    --enable-libfontconfig
+    --enable-shared
+    --enable-avresample
+    --enable-pthreads
+    --enable-version3
+    --enable-hardcoded-tables
+    --cc=clang 
+    --host-cflags=-fPIC
+    --host-ldflags=
+    --enable-gpl
+    --enable-libmp3lame
+    --enable-libx264
+    --enable-libx265
+    --enable-libxvid
+    --enable-opencl
+    --disable-lzma
+)
+
+if [ "$1" == "--DEBUG" ] || [ "$1" == "--debug" ]; then
+    CONFIGURE_TO_USE="./configure.debug"
+    command_options+=(
+        --disable-stripping
+        --enable-debug=3
+        --extra-cflags=-ggdb
+        --extra-cflags=-O0
+        --extra-cflags=-g
+    )
+fi
+
 if [ "$(uname)" == "Darwin" ]; then
-
+    command_options+=(
+        --enable-videotoolbox
+    )
     HOMEBREW_LOCATION="$(brew --prefix)"
-    CONFIGURE_HOMEBREW=""
     if [ -n "${HOMEBREW_LOCATION}" -a -d "${HOMEBREW_LOCATION}" ]; then
-        CONFIGURE_HOMEBREW="--extra-ldflags=-L${HOMEBREW_LOCATION}/lib  --extra-cflags=-I${HOMEBREW_LOCATION}/include"
+        command_options+=(
+            --extra-ldflags=-L${HOMEBREW_LOCATION}/lib
+            --extra-cflags=-I${HOMEBREW_LOCATION}/include
+        )
     fi
-
-    if [ "$1" == "--DEBUG" ] || [ "$1" == "--debug" ]; then
-        command_options="--prefix=${DIST} --enable-libfreetype --enable-libfribidi --enable-libfontconfig --enable-shared --enable-avresample --enable-pthreads --enable-version3 --enable-hardcoded-tables --cc=clang --host-cflags=-fPIC --host-ldflags=  --enable-gpl --enable-libmp3lame --enable-libx264 --enable-libx265 --enable-libxvid --enable-opencl --enable-videotoolbox --disable-lzma --disable-stripping --enable-debug=3 --extra-cflags=-ggdb --extra-cflags=-O0 --extra-cflags=-g ${CONFIGURE_HOMEBREW}"
-        CONFIGURE_TO_USE="./configure.debug"
-    else
-        command_options="--prefix=${DIST} --enable-libfreetype --enable-libfribidi --enable-libfontconfig --enable-shared --enable-avresample --enable-pthreads --enable-version3 --enable-hardcoded-tables --cc=clang --host-cflags=-fPIC --host-ldflags=  --enable-gpl --enable-libmp3lame --enable-libx264 --enable-libx265 --enable-libxvid --enable-opencl --enable-videotoolbox --disable-lzma ${CONFIGURE_HOMEBREW}"
-    fi
-    echo "configuring with command_options=${command_options}"
-    ${CONFIGURE_TO_USE} ${command_options}
+    echo "configuring with command_options=${command_options[@]}"
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-    if [ "$1" == "--DEBUG" ] || [ "$1" == "--debug" ]; then
-        command_options="--prefix=${DIST} --enable-libfreetype --enable-libfribidi --enable-libfontconfig --enable-shared --enable-avresample --enable-pthreads --enable-version3 --enable-hardcoded-tables --cc=clang --host-cflags=-fPIC --host-ldflags= --extra-cflags=-fPIC --enable-gpl --enable-libmp3lame --enable-libx264 --enable-libx265 --enable-libxvid --enable-opencl --disable-lzma --disable-stripping --enable-debug=3 --extra-cflags=-ggdb --extra-cflags=-O0 --extra-cflags=-g"
-        CONFIGURE_TO_USE="./configure.debug"
-    else
-        command_options="--prefix=${DIST} --enable-libfreetype --enable-libfribidi --enable-libfontconfig --enable-shared --enable-avresample --enable-pthreads --enable-version3 --enable-hardcoded-tables --cc=clang --host-cflags=-fPIC --host-ldflags= --extra-cflags=-fPIC --enable-gpl --enable-libmp3lame --enable-libx264 --enable-libx265 --enable-libxvid --enable-opencl --disable-lzma"
+    command_options+=(
+        --extra-cflags=-fPIC
+    )
+    if find /usr/local/cuda* -name version.txt | read; then
+        if [ -d /usr/local/cuda/include -a -d /usr/local/cuda/lib64 ]; then
+            command_options+=(
+                --enable-cuda
+                --enable-cuvid
+                --enable-nvenc
+                --enable-nonfree
+                --enable-libnpp
+                --extra-cflags=-I/usr/local/cuda/include
+                --extra-ldflags=-L/usr/local/cuda/lib64
+            )
+        else
+            echo "CUDA found, but not linked to /usr/local/cuda, so skipping setup"
+        fi
     fi
-    FLAGS_NVIDIA=""
-    if [ -d /usr/local/cuda/ ]
-    then
-        FLAGS_NVIDIA="--enable-cuda --enable-cuvid --enable-nvenc --enable-nonfree --enable-libnpp --extra-cflags=-I/usr/local/cuda/include --extra-ldflags=-L/usr/local/cuda/lib64"
-    fi
-    echo "configuring with command_options=${FLAGS_NVIDIA} ${command_options}"
-    ${CONFIGURE_TO_USE} ${FLAGS_NVIDIA} ${command_options}
+    echo "configuring with command_options=${command_options[@]}"
+    
 elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ]; then
     echo "MINGW32 Not yet supported"
+    exit 1
 elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW64_NT" ]; then
     echo "MINGW64 Not yet supported"
+    exit 1
 fi
+
+${CONFIGURE_TO_USE} ${command_options[@]}
 
 NPROCS=$(getconf _NPROCESSORS_ONLN)
 ELUVIO_BUILD_THREAD_COUNT=${ELUVIO_BUILD_THREAD_COUNT:-"-j${NPROCS}"}


### PR DESCRIPTION
The build args had a lot of duplication and the lines got too long for readability.  This moves the common arguments into arrays that are expanded into a string on execution.  The args are added as conditions are met, so the arg list is built in a readable way rather than a huge monolith.  Also added some safety checks like ensuring work happens in the repo dir and not some other place.