### PR TITLE
Fix netint mac compile errors

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,7 @@ CONFIGURE_TO_USE="./configure"
 
 # Build netint libxcoder and install it in $DIST
 (
+if [ "$(uname -s)" != "Darwin" ]; then
     export DIST
     cd libxcoder
     if [ "$1" == "--DEBUG" ] || [ "$1" == "--debug" ]; then
@@ -17,6 +18,7 @@ CONFIGURE_TO_USE="./configure"
     else
         ./build.sh
     fi
+fi
 )
 
 export PKG_CONFIG_PATH=${DIST}/lib/pkgconfig:${PKG_CONFIG_PATH}

--- a/libavfilter/allfilters.c
+++ b/libavfilter/allfilters.c
@@ -566,7 +566,7 @@ const AVFilter *avfilter_get_by_name(const char *name)
         return NULL;
 
     while ((f = av_filter_iterate(&opaque)))
-        if (!strcmp(f->name, name))
+        if (f->name != NULL && !strcmp(f->name, name))
             return f;
 
     return NULL;

--- a/libavfilter/nifilter.c
+++ b/libavfilter/nifilter.c
@@ -22,7 +22,7 @@
  * @file
  * video common filter routines
  */
-
+#ifndef __APPLE__
 #include <stdio.h>
 
 #include <ni_device_api.h>
@@ -279,3 +279,4 @@ void ff_ni_clone_hwframe_ctx(AVHWFramesContext *in_frames_ctx,
   }
   
 }
+#endif

--- a/libavfilter/nifilter.h
+++ b/libavfilter/nifilter.h
@@ -25,6 +25,7 @@
  * XCoder codec lib wrapper.
  */
 
+#ifndef __APPLE__
 #ifndef AVFILTER_NIFILTER_H
 #define AVFILTER_NIFILTER_H
 
@@ -48,4 +49,5 @@ void ff_ni_clone_hwframe_ctx(AVHWFramesContext *in_frames_ctx,
                              AVHWFramesContext *out_frames_ctx,
                              ni_session_context_t *ctx);
 
+#endif
 #endif

--- a/libavfilter/vf_bg_ni.c
+++ b/libavfilter/vf_bg_ni.c
@@ -16,6 +16,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#ifndef __APPLE__
 #include <float.h>
 #include <math.h>
 #include <stdio.h>
@@ -1527,3 +1528,7 @@ AVFilter ff_vf_bg_ni_quadra = {
     .query_formats = nibg_query_formats,
 #endif
 };
+#else
+#include "avfilter.h"
+AVFilter ff_vf_bg_ni_quadra = {};
+#endif

--- a/libavfilter/vf_crop_ni.c
+++ b/libavfilter/vf_crop_ni.c
@@ -24,6 +24,7 @@
  * video crop filter
  */
 
+#ifndef __APPLE__
 #include <stdio.h>
 
 #include "avfilter.h"
@@ -615,3 +616,7 @@ AVFilter ff_vf_crop_ni_quadra = {
     .query_formats   = query_formats,
 #endif
 };
+#else
+#include "avfilter.h"
+AVFilter ff_vf_crop_ni_quadra = {};
+#endif

--- a/libavfilter/vf_drawbox_ni.c
+++ b/libavfilter/vf_drawbox_ni.c
@@ -24,6 +24,7 @@
  * drawbox video filter
  */
 
+#ifndef __APPLE__
 #include <stdio.h>
 #include <string.h>
 
@@ -709,3 +710,7 @@ AVFilter ff_vf_drawbox_ni_quadra = {
     .query_formats   = query_formats,
 #endif
 };
+#else
+#include "avfilter.h"
+AVFilter ff_vf_drawbox_ni_quadra = {};
+#endif

--- a/libavfilter/vf_hwupload_ni_logan.c
+++ b/libavfilter/vf_hwupload_ni_logan.c
@@ -16,6 +16,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#ifndef __APPLE__
 #include "libavutil/buffer.h"
 #include "libavutil/hwcontext.h"
 #include "libavutil/hwcontext_ni_logan.h"
@@ -23,7 +24,6 @@
 #include "libavutil/log.h"
 #include "libavutil/opt.h"
 
-#include "avfilter.h"
 #include "formats.h"
 #include "internal.h"
 #include "video.h"
@@ -228,3 +228,7 @@ AVFilter ff_vf_hwupload_ni_logan = {
 
     .flags_internal = FF_FILTER_FLAG_HWFRAME_AWARE,
 };
+#else
+#include "avfilter.h"
+AVFilter ff_vf_hwupload_ni_logan = {};
+#endif

--- a/libavfilter/vf_hwupload_ni_quadra.c
+++ b/libavfilter/vf_hwupload_ni_quadra.c
@@ -16,6 +16,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#ifndef __APPLE__
 #include "libavutil/buffer.h"
 #include "libavutil/hwcontext.h"
 #include "libavutil/hwcontext_ni_quad.h"
@@ -268,3 +269,7 @@ AVFilter ff_vf_hwupload_ni_quadra = {
     .query_formats = niupload_query_formats,
 #endif
 };
+#else
+#include "avfilter.h"
+AVFilter ff_vf_hwupload_ni_quadra = {};
+#endif

--- a/libavfilter/vf_overlay_ni.c
+++ b/libavfilter/vf_overlay_ni.c
@@ -27,6 +27,7 @@
  * overlay one video on top of another
  */
 
+#ifndef __APPLE__
 #include "avfilter.h"
 #include "formats.h"
 #include "libavutil/common.h"
@@ -726,3 +727,7 @@ AVFilter ff_vf_overlay_ni_quadra = {
 #endif
     .flags_internal= FF_FILTER_FLAG_HWFRAME_AWARE
 };
+#else
+#include "avfilter.h"
+AVFilter ff_vf_overlay_ni_quadra = {};
+#endif

--- a/libavfilter/vf_pad_ni.c
+++ b/libavfilter/vf_pad_ni.c
@@ -24,6 +24,7 @@
  * video padding filter
  */
 
+#ifndef __APPLE__
 #include <float.h>  /* DBL_MAX */
 
 #include "avfilter.h"
@@ -616,3 +617,7 @@ AVFilter ff_vf_pad_ni_quadra = {
     .query_formats = query_formats,
 #endif
 };
+#else
+#include "avfilter.h"
+AVFilter ff_vf_pad_ni_quadra = {};
+#endif

--- a/libavfilter/vf_roi_ni.c
+++ b/libavfilter/vf_roi_ni.c
@@ -18,6 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#ifndef __APPLE__
 #include <float.h>
 #include <math.h>
 #include <stdio.h>
@@ -1343,3 +1344,7 @@ AVFilter ff_vf_roi_ni_quadra = {
     .query_formats  = ni_roi_query_formats,
 #endif
 };
+#else
+#include "avfilter.h"
+AVFilter ff_vf_roi_ni_quadra = {};
+#endif

--- a/libavfilter/vf_rotate_ni.c
+++ b/libavfilter/vf_rotate_ni.c
@@ -25,6 +25,7 @@
  * rotation filter, based on the FFmpeg rotate filter
 */
 
+#ifndef __APPLE__
 #include <string.h>
 
 #include "libavutil/eval.h"
@@ -717,3 +718,7 @@ AVFilter ff_vf_rotate_ni_quadra = {
 #endif
     .flags_internal = FF_FILTER_FLAG_HWFRAME_AWARE,
 };
+#else
+#include "avfilter.h"
+AVFilter ff_vf_rotate_ni_quadra = {};
+#endif

--- a/libavfilter/vf_scale_ni.c
+++ b/libavfilter/vf_scale_ni.c
@@ -24,6 +24,7 @@
  * scale video filter
  */
 
+#ifndef __APPLE__
 #include <stdio.h>
 #include <string.h>
 
@@ -627,3 +628,7 @@ AVFilter ff_vf_scale_ni_quadra = {
     .query_formats   = query_formats,
 #endif
 };
+#else
+#include "avfilter.h"
+AVFilter ff_vf_scale_ni_quadra = {};
+#endif

--- a/libavfilter/vf_split_ni.c
+++ b/libavfilter/vf_split_ni.c
@@ -24,6 +24,7 @@
  * audio and video splitter
  */
 
+#ifndef __APPLE__
 #include <stdio.h>
 
 #include "libavutil/attributes.h"
@@ -534,3 +535,7 @@ AVFilter ff_vf_split_ni_quadra = {
     .query_formats  = query_formats,
 #endif
 };
+#else
+#include "avfilter.h"
+AVFilter ff_vf_split_ni_quadra = {};
+#endif

--- a/libavfilter/vf_stack_ni.c
+++ b/libavfilter/vf_stack_ni.c
@@ -19,6 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#ifndef __APPLE__
 #include "libavutil/avstring.h"
 #include "libavutil/imgutils.h"
 #include "libavutil/opt.h"
@@ -727,3 +728,7 @@ AVFilter ff_vf_xstack_ni_quadra = {
     .query_formats = query_formats,
 #endif
 };
+#else
+#include "avfilter.h"
+AVFilter ff_vf_xstack_ni_quadra = {};
+#endif

--- a/libavfilter/vf_yuv420to444_ni.c
+++ b/libavfilter/vf_yuv420to444_ni.c
@@ -21,6 +21,7 @@
  * yuv420 to yuv444
  */
 
+#ifndef __APPLE__
 #include "avfilter.h"
 #include "formats.h"
 #include "libavutil/common.h"
@@ -326,3 +327,7 @@ AVFilter ff_vf_yuv420to444_ni_quadra = {
     .flags         = AVFILTER_FLAG_SUPPORT_TIMELINE_INTERNAL |
                      AVFILTER_FLAG_SLICE_THREADS,
 };
+#else
+#include "avfilter.h"
+AVFilter ff_vf_yuv420to444_ni_quadra = {};
+#endif

--- a/libavfilter/vf_yuv444to420_ni.c
+++ b/libavfilter/vf_yuv444to420_ni.c
@@ -22,6 +22,7 @@
  * yuv444 to yuv420
  */
 
+#ifndef __APPLE__
 #include <stdio.h>
 #include "libavutil/attributes.h"
 #include "libavutil/avstring.h"
@@ -285,3 +286,7 @@ AVFilter ff_vf_yuv444to420_ni_quadra = {
 #endif
     .flags         = AVFILTER_FLAG_DYNAMIC_OUTPUTS,
 };
+#else
+#include "avfilter.h"
+AVFilter ff_vf_yuv444to420_ni_quadra = {};
+#endif


### PR DESCRIPTION
- This patch fixes the netint ffmpeg compile errors on mac by avoiding compilation of netint related files on mac.
- Netint related files will be compile only on non-mac environments.