### PR TITLE
av_get_frame_filename2 uses int64_t

### DIFF
--- a/libavformat/avformat.h
+++ b/libavformat/avformat.h
@@ -2825,16 +2825,20 @@ void av_dump_format(AVFormatContext *ic,
  *
  * Also handles the '%0nd' format where 'n' is the total number
  * of digits and '%%'.
+ * 
+ * ELUVIO MERGE NOTE: This was modified in order to adjust the number from int to int64_t. When
+ * upgrading to ffmpeg 7.2, this change will become unnecessary, and the commit can be discarded
+ * when merging/rebasing.
  *
  * @param buf destination buffer
  * @param buf_size destination buffer size
  * @param path numbered sequence string
- * @param number frame number
+ * @param number frame number or PTS
  * @param flags AV_FRAME_FILENAME_FLAGS_*
  * @return 0 if OK, -1 on format error
  */
 int av_get_frame_filename2(char *buf, int buf_size,
-                          const char *path, int number, int flags);
+                          const char *path, int64_t number, int flags);
 
 int av_get_frame_filename(char *buf, int buf_size,
                           const char *path, int number);

--- a/libavformat/utils.c
+++ b/libavformat/utils.c
@@ -4733,7 +4733,7 @@ uint64_t ff_get_formatted_ntp_time(uint64_t ntp_time_us)
     return ntp_ts;
 }
 
-int av_get_frame_filename2(char *buf, int buf_size, const char *path, int number, int flags)
+int av_get_frame_filename2(char *buf, int buf_size, const char *path, int64_t number, int flags)
 {
     const char *p;
     char *q, buf1[20], c;
@@ -4766,7 +4766,7 @@ int av_get_frame_filename2(char *buf, int buf_size, const char *path, int number
                 percentd_found = 1;
                 if (number < 0)
                     nd += 1;
-                snprintf(buf1, sizeof(buf1), "%0*d", nd, number);
+                snprintf(buf1, sizeof(buf1), "%0*" PRId64, nd, number);
                 len = strlen(buf1);
                 if ((q - buf + len) > buf_size - 1)
                     goto fail;


### PR DESCRIPTION
This fixes an overflow bug in frame filenames created with PTS values. This commit can be removed once upgrading to ffmpeg trunk, as it is very similar to this commit:

https://github.com/FFmpeg/FFmpeg/commit/a2d9663241908d6f558b8e6b24bd42f2aaebc144