### PR TITLE
ELUVIO - add CENC and CBCS pattern encryption and AES-128 DASH segment encryption

### DIFF
--- a/libavcodec/h2645_parse.h
+++ b/libavcodec/h2645_parse.h
@@ -69,6 +69,8 @@ typedef struct H2645NAL {
     int skipped_bytes;
     int skipped_bytes_pos_size;
     int *skipped_bytes_pos;
+
+    int slice_header_len_bits;
 } H2645NAL;
 
 typedef struct H2645RBSP {

--- a/libavcodec/h264_parser.c
+++ b/libavcodec/h264_parser.c
@@ -39,12 +39,14 @@
 #include "get_bits.h"
 #include "golomb.h"
 #include "h264.h"
+#include "h264dec.h"
 #include "h264dsp.h"
 #include "h264_parse.h"
 #include "h264_sei.h"
 #include "h264_ps.h"
 #include "h2645_parse.h"
 #include "h264data.h"
+#include "internal.h"
 #include "mpegutils.h"
 #include "parser.h"
 #include "libavutil/refstruct.h"
@@ -59,13 +61,22 @@ typedef struct H264ParseContext {
     int is_avc;
     int nal_length_size;
     int got_first;
-    int picture_structure;
+    enum AVPictureStructure picture_structure, last_picture_structure;
     uint8_t parse_history[6];
     int parse_history_count;
     int parse_last_mb;
     int64_t reference_dts;
-    int last_frame_num, last_picture_structure;
+    int last_frame_num;
+    int curr_pic_num, max_pic_num;
+    MMCO mmco[H264_MAX_MMCO_COUNT];
+    H2645NAL nals[MAX_SLICES]; // assume MAX_SLICES is the most NALs in a packet
 } H264ParseContext;
+
+void* avpriv_h264_extract_nals(AVCodecParserContext *s)
+{
+    H264ParseContext *p = s->priv_data;
+    return p->nals;
+}
 
 static int find_start_code(const uint8_t *buf, int buf_size,
                                   int buf_index, int next_avc)
@@ -247,6 +258,335 @@ static int scan_mmco_reset(AVCodecParserContext *s, GetBitContext *gb,
 }
 
 /**
+ * Copy of:
+ *   int ff_h264_decode_ref_pic_marking(H264SliceContext *sl, GetBitContext *gb,
+ *                                      const H2645NAL *nal, void *logctx)
+ */
+static int decode_ref_pic_marking(H264ParseContext *p, GetBitContext *gb,
+                                  const H2645NAL *nal, void *logctx)
+{
+    int i;
+    MMCO *mmco = p->mmco;
+    // int nb_mmco = 0;
+    int explicit_ref_marking;
+
+    if (nal->type == H264_NAL_IDR_SLICE) { // FIXME fields
+        skip_bits1(gb); // broken_link
+        if (get_bits1(gb)) {
+            mmco[0].opcode   = MMCO_LONG;
+            mmco[0].long_arg = 0;
+            // nb_mmco          = 1;
+        }
+        explicit_ref_marking = 1;
+    } else {
+        explicit_ref_marking = get_bits1(gb);
+        if (explicit_ref_marking) {
+            for (i = 0; i < H264_MAX_MMCO_COUNT; i++) {
+                MMCOOpcode opcode = get_ue_golomb_31(gb);
+
+                mmco[i].opcode = opcode;
+                if (opcode == MMCO_SHORT2UNUSED || opcode == MMCO_SHORT2LONG) {
+                    mmco[i].short_pic_num =
+                        (p->curr_pic_num - get_ue_golomb_long(gb) - 1) &
+                            (p->max_pic_num - 1);
+                }
+                if (opcode == MMCO_SHORT2LONG || opcode == MMCO_LONG2UNUSED ||
+                    opcode == MMCO_LONG || opcode == MMCO_SET_MAX_LONG) {
+                    unsigned int long_arg = get_ue_golomb_31(gb);
+                    if (long_arg >= 32 ||
+                        (long_arg >= 16 && !(opcode == MMCO_SET_MAX_LONG &&
+                                             long_arg == 16) &&
+                         !(opcode == MMCO_LONG2UNUSED && FIELD_PICTURE(p)))) {
+                        av_log(logctx, AV_LOG_ERROR,
+                               "illegal long ref in memory management control "
+                               "operation %d\n", opcode);
+                        // nb_mmco = i;
+                        return -1;
+                    }
+                    mmco[i].long_arg = long_arg;
+                }
+
+                if (opcode > (unsigned) MMCO_LONG) {
+                    av_log(logctx, AV_LOG_ERROR,
+                           "illegal memory management control operation %d\n",
+                           opcode);
+                    // nb_mmco = i;
+                    return -1;
+                }
+                if (opcode == MMCO_END)
+                    break;
+            }
+            // nb_mmco = i;
+        }
+    }
+
+    return 0;
+}
+
+/**
+ * Significant portions copied from h264_slice_header_parse
+ */
+static int parse_slice(AVCodecParserContext *s, AVCodecContext *avctx,
+                       H2645NAL *nal)
+{
+    GetBitContext *gb = &nal->gb;
+    H264ParseContext *p = s->priv_data;
+    const PPS *pps = p->ps.pps;
+    const SPS *sps = p->ps.sps;
+    int field_poc[2];
+    int ret;
+    int slice_type_nos = s->pict_type & 3;
+    int list_count, ref_count[2];
+    int index, tmp, i;
+    H264PredWeightTable pwt;
+    int got_reset = 0;
+    int deblocking_filter;
+
+    /* Decode POC of this picture.
+    * The prev_ values needed for decoding POC of the next picture are not set here. */
+    field_poc[0] = field_poc[1] = INT_MAX;
+    ret = ff_h264_init_poc(field_poc, &s->output_picture_number, sps,
+                           &p->poc, p->picture_structure, nal->ref_idc);
+    if (ret < 0)
+        return ret;
+
+    if (pps->redundant_pic_cnt_present)
+        get_ue_golomb(gb); /* redundant_pic_cnt */
+
+    if (slice_type_nos == AV_PICTURE_TYPE_B)
+        get_bits1(gb); /* direct_spatial_mv_pred_flag */
+
+    /* num_ref_idx_active_override_flag */
+    if (ff_h264_parse_ref_count(&list_count, ref_count, gb, pps,
+                                slice_type_nos, p->picture_structure, avctx) < 0)
+        return AVERROR_INVALIDDATA;
+
+    /* ref_pic_list_modification */
+    if (slice_type_nos != AV_PICTURE_TYPE_I) {
+        /* ff_h264_decode_ref_pic_list_reordering */
+        int list;
+        for (list = 0; list < list_count; list++) {
+            if (!get_bits1(gb))    // ref_pic_list_modification_flag_l[01]
+                continue;
+
+            for (index = 0; ; index++) {
+                unsigned int reordering_of_pic_nums_idc = get_ue_golomb_31(gb);
+
+                if (reordering_of_pic_nums_idc < 3)
+                    get_ue_golomb_long(gb);
+                else if (reordering_of_pic_nums_idc > 3) {
+                    av_log(avctx, AV_LOG_ERROR,
+                            "illegal reordering_of_pic_nums_idc %d\n",
+                            reordering_of_pic_nums_idc);
+                    return AVERROR_INVALIDDATA;
+                } else
+                    break;
+
+                if (index >= ref_count[list]) {
+                    av_log(avctx, AV_LOG_ERROR,
+                            "reference count %d overflow\n", index);
+                    return AVERROR_INVALIDDATA;
+                }
+            }
+        }
+    }
+
+    /* pred_weight_table */
+    if ((pps->weighted_pred && slice_type_nos == AV_PICTURE_TYPE_P) ||
+        (pps->weighted_bipred_idc == 1 && slice_type_nos == AV_PICTURE_TYPE_B))
+        ff_h264_pred_weight_table(gb, sps, ref_count, slice_type_nos,
+                                  &pwt, p->picture_structure, avctx);
+
+    /* dec_ref_pic_marking - sets mmco */
+    if (nal->ref_idc) {
+        ret = decode_ref_pic_marking(p, gb, nal, avctx);
+        if (ret < 0 && (avctx->err_recognition & AV_EF_EXPLODE))
+            return AVERROR_INVALIDDATA;
+    }
+    
+    /* FIXME: MMCO_RESET could appear in non-first slice.
+    *        Maybe, we should parse all undisposable non-IDR slice of this
+    *        picture until encountering MMCO_RESET in a slice of it. */
+    /* Compare with: got_reset = scan_mmco_reset(s, &nal.gb, avctx);*/
+    for (i = 0; (unsigned int)i < H264_MAX_MMCO_COUNT; i++) {
+        if (p->mmco[i].opcode == MMCO_END)
+            break;
+        if (p->mmco[i].opcode == MMCO_RESET) {
+            got_reset = 1;
+            break;
+        }
+    }
+
+    /* Set up the prev_ values for decoding POC of the next picture. */
+    p->poc.prev_frame_num        = got_reset ? 0 : p->poc.frame_num;
+    p->poc.prev_frame_num_offset = got_reset ? 0 : p->poc.frame_num_offset;
+    if (nal->ref_idc != 0) {
+        if (!got_reset) {
+            p->poc.prev_poc_msb = p->poc.poc_msb;
+            p->poc.prev_poc_lsb = p->poc.poc_lsb;
+        } else {
+            p->poc.prev_poc_msb = 0;
+            p->poc.prev_poc_lsb =
+                p->picture_structure == PICT_BOTTOM_FIELD ? 0 : field_poc[0];
+        }
+    }
+
+    if (p->sei.picture_timing.present) {
+        ret = ff_h264_sei_process_picture_timing(&p->sei.picture_timing,
+                                                    sps, avctx);
+        if (ret < 0) {
+            av_log(avctx, AV_LOG_ERROR, "Error processing the picture timing SEI\n");
+            p->sei.picture_timing.present = 0;
+        }
+    }
+
+    if (sps->pic_struct_present_flag && p->sei.picture_timing.present) {
+        switch (p->sei.picture_timing.pic_struct) {
+        case H264_SEI_PIC_STRUCT_TOP_FIELD:
+        case H264_SEI_PIC_STRUCT_BOTTOM_FIELD:
+            s->repeat_pict = 0;
+            break;
+        case H264_SEI_PIC_STRUCT_FRAME:
+        case H264_SEI_PIC_STRUCT_TOP_BOTTOM:
+        case H264_SEI_PIC_STRUCT_BOTTOM_TOP:
+            s->repeat_pict = 1;
+            break;
+        case H264_SEI_PIC_STRUCT_TOP_BOTTOM_TOP:
+        case H264_SEI_PIC_STRUCT_BOTTOM_TOP_BOTTOM:
+            s->repeat_pict = 2;
+            break;
+        case H264_SEI_PIC_STRUCT_FRAME_DOUBLING:
+            s->repeat_pict = 3;
+            break;
+        case H264_SEI_PIC_STRUCT_FRAME_TRIPLING:
+            s->repeat_pict = 5;
+            break;
+        default:
+            s->repeat_pict = p->picture_structure == PICT_FRAME ? 1 : 0;
+            break;
+        }
+    } else {
+        s->repeat_pict = p->picture_structure == PICT_FRAME ? 1 : 0;
+    }
+
+    if (p->picture_structure == PICT_FRAME) {
+        s->picture_structure = AV_PICTURE_STRUCTURE_FRAME;
+        if (sps->pic_struct_present_flag && p->sei.picture_timing.present) {
+            switch (p->sei.picture_timing.pic_struct) {
+            case H264_SEI_PIC_STRUCT_TOP_BOTTOM:
+            case H264_SEI_PIC_STRUCT_TOP_BOTTOM_TOP:
+                s->field_order = AV_FIELD_TT;
+                break;
+            case H264_SEI_PIC_STRUCT_BOTTOM_TOP:
+            case H264_SEI_PIC_STRUCT_BOTTOM_TOP_BOTTOM:
+                s->field_order = AV_FIELD_BB;
+                break;
+            default:
+                s->field_order = AV_FIELD_PROGRESSIVE;
+                break;
+            }
+        } else {
+            if (field_poc[0] < field_poc[1])
+                s->field_order = AV_FIELD_TT;
+            else if (field_poc[0] > field_poc[1])
+                s->field_order = AV_FIELD_BB;
+            else
+                s->field_order = AV_FIELD_PROGRESSIVE;
+        }
+    } else {
+        if (p->picture_structure == PICT_TOP_FIELD)
+            s->picture_structure = AV_PICTURE_STRUCTURE_TOP_FIELD;
+        else
+            s->picture_structure = AV_PICTURE_STRUCTURE_BOTTOM_FIELD;
+        if (p->poc.frame_num == p->last_frame_num &&
+            p->last_picture_structure != AV_PICTURE_STRUCTURE_UNKNOWN &&
+            p->last_picture_structure != AV_PICTURE_STRUCTURE_FRAME &&
+            p->last_picture_structure != s->picture_structure) {
+            if (p->last_picture_structure == AV_PICTURE_STRUCTURE_TOP_FIELD)
+                s->field_order = AV_FIELD_TT;
+            else
+                s->field_order = AV_FIELD_BB;
+        } else {
+            s->field_order = AV_FIELD_UNKNOWN;
+        }
+        p->last_picture_structure = s->picture_structure;
+        p->last_frame_num = p->poc.frame_num;
+    }
+
+    if (sps->timing_info_present_flag)
+    {
+        int64_t den = sps->time_scale;
+        if (p->sei.common.unregistered.x264_build < 44U)
+            den *= 2;
+        av_reduce(&avctx->framerate.den, &avctx->framerate.num,
+                  sps->num_units_in_tick * 2, den, 1 << 30);
+    }
+
+    /* cabac_init_idc */
+    if (slice_type_nos != AV_PICTURE_TYPE_I && pps->cabac) {
+        tmp = get_ue_golomb_31(gb);
+        if (tmp > 2) {
+            av_log(avctx, AV_LOG_ERROR, "cabac_init_idc %u overflow\n", tmp);
+            return AVERROR_INVALIDDATA;
+        }
+        // sl->cabac_init_idc = tmp;
+    }
+
+    /* slice_qp_delta */
+    // sl->last_qscale_diff = 0;
+    // tmp = pps->init_qp + (unsigned)get_se_golomb(&sl->gb);
+    tmp = pps->init_qp + (unsigned)get_se_golomb(gb);
+    if (tmp > 51 + 6 * (sps->bit_depth_luma - 8)) {
+        av_log(avctx, AV_LOG_ERROR, "QP %u out of range\n", tmp);
+        return AVERROR_INVALIDDATA;
+    }
+    // sl->qscale       = tmp;
+    // sl->chroma_qp[0] = get_chroma_qp(pps, 0, sl->qscale);
+    // sl->chroma_qp[1] = get_chroma_qp(pps, 1, sl->qscale);
+    // FIXME qscale / qp ... stuff
+    if (s->pict_type == AV_PICTURE_TYPE_SP)
+        get_bits1(gb); /* sp_for_switch_flag */
+    if (s->pict_type == AV_PICTURE_TYPE_SP ||
+        s->pict_type == AV_PICTURE_TYPE_SI)
+        get_se_golomb(gb); /* slice_qs_delta */
+
+    // sl->deblocking_filter     = 1;
+    // sl->slice_alpha_c0_offset = 0;
+    // sl->slice_beta_offset     = 0;
+    if (pps->deblocking_filter_parameters_present) {
+        tmp = get_ue_golomb_31(gb); /* disable_deblocking_filter_idc */
+        if (tmp > 2) {
+            av_log(avctx, AV_LOG_ERROR,
+                   "deblocking_filter_idc %u out of range\n", tmp);
+            return AVERROR_INVALIDDATA;
+        }
+        deblocking_filter = tmp;
+        if (deblocking_filter < 2)
+            deblocking_filter ^= 1;  // 1<->0
+
+        if (deblocking_filter) {
+            int slice_alpha_c0_offset_div2 = get_se_golomb(gb);
+            int slice_beta_offset_div2     = get_se_golomb(gb);
+            if (slice_alpha_c0_offset_div2 >  6 ||
+                slice_alpha_c0_offset_div2 < -6 ||
+                slice_beta_offset_div2 >  6     ||
+                slice_beta_offset_div2 < -6) {
+                av_log(avctx, AV_LOG_ERROR,
+                       "deblocking filter parameters %d %d out of range\n",
+                       slice_alpha_c0_offset_div2, slice_beta_offset_div2);
+                return AVERROR_INVALIDDATA;
+            }
+            // sl->slice_alpha_c0_offset = slice_alpha_c0_offset_div2 * 2;
+            // sl->slice_beta_offset     = slice_beta_offset_div2 * 2;
+        }
+    }
+
+    /* slice_group_change_cycle */
+
+    return 0;
+}
+
+/**
  * Parse NAL units of found picture and decode some basic information.
  *
  * @param s parser context.
@@ -260,14 +600,17 @@ static inline int parse_nal_units(AVCodecParserContext *s,
 {
     H264ParseContext *p = s->priv_data;
     H2645RBSP rbsp = { NULL };
-    H2645NAL nal = { NULL };
+    H2645NAL *nal;
     int buf_index, next_avc;
     unsigned int pps_id;
     unsigned int slice_type;
-    int state = -1, got_reset = 0;
+    int state = -1;
     int q264 = buf_size >=4 && !memcmp("Q264", buf, 4);
-    int field_poc[2];
     int ret;
+    int nal_index = 0;
+    int picture_found = 0;
+
+    memset(p->nals, 0, sizeof(p->nals));
 
     /* set some sane default values */
     s->pict_type         = AV_PICTURE_TYPE_I;
@@ -304,8 +647,14 @@ static inline int parse_nal_units(AVCodecParserContext *s,
                 continue;
         }
         src_length = next_avc - buf_index;
-
         state = buf[buf_index];
+
+        if ((unsigned int)nal_index >= MAX_SLICES) {
+            av_log(avctx, AV_LOG_WARNING, "reached NAL parse limit: %d\n", MAX_SLICES);
+            goto fail;
+        }
+        nal = &p->nals[nal_index];
+
         switch (state & 0x1f) {
         case H264_NAL_SLICE:
         case H264_NAL_IDR_SLICE:
@@ -322,29 +671,29 @@ static inline int parse_nal_units(AVCodecParserContext *s,
             }
             break;
         }
-        consumed = ff_h2645_extract_rbsp(buf + buf_index, src_length, &rbsp, &nal, 1);
+        consumed = ff_h2645_extract_rbsp(buf + buf_index, src_length, &rbsp, nal, 1);
         if (consumed < 0)
             break;
 
         buf_index += consumed;
 
-        ret = init_get_bits8(&nal.gb, nal.data, nal.size);
+        ret = init_get_bits8(&nal->gb, nal->data, nal->size);
         if (ret < 0)
             goto fail;
-        get_bits1(&nal.gb);
-        nal.ref_idc = get_bits(&nal.gb, 2);
-        nal.type    = get_bits(&nal.gb, 5);
+        get_bits1(&nal->gb);
+        nal->ref_idc = get_bits(&nal->gb, 2);
+        nal->type    = get_bits(&nal->gb, 5);
 
-        switch (nal.type) {
+        switch (nal->type) {
         case H264_NAL_SPS:
-            ff_h264_decode_seq_parameter_set(&nal.gb, avctx, &p->ps, 0);
+            ff_h264_decode_seq_parameter_set(&nal->gb, avctx, &p->ps, 0);
             break;
         case H264_NAL_PPS:
-            ff_h264_decode_picture_parameter_set(&nal.gb, avctx, &p->ps,
-                                                 nal.size_bits);
+            ff_h264_decode_picture_parameter_set(&nal->gb, avctx, &p->ps,
+                                                 nal->size_bits);
             break;
         case H264_NAL_SEI:
-            ff_h264_sei_decode(&p->sei, &nal.gb, &p->ps, avctx);
+            ff_h264_sei_decode(&p->sei, &nal->gb, &p->ps, avctx);
             break;
         case H264_NAL_IDR_SLICE:
             s->key_frame = 1;
@@ -355,14 +704,15 @@ static inline int parse_nal_units(AVCodecParserContext *s,
             p->poc.prev_poc_lsb          = 0;
         /* fall through */
         case H264_NAL_SLICE:
-            get_ue_golomb_long(&nal.gb);  // skip first_mb_in_slice
-            slice_type   = get_ue_golomb_31(&nal.gb);
+            picture_found = 1;
+            get_ue_golomb_long(&nal->gb);  // skip first_mb_in_slice
+            slice_type   = get_ue_golomb_31(&nal->gb);
             s->pict_type = ff_h264_golomb_to_pict_type[slice_type % 5];
             if (p->sei.recovery_point.recovery_frame_cnt >= 0) {
                 /* key frame, since recovery_frame_cnt is set */
                 s->key_frame = 1;
             }
-            pps_id = get_ue_golomb(&nal.gb);
+            pps_id = get_ue_golomb(&nal->gb);
             if (pps_id >= MAX_PPS_COUNT) {
                 av_log(avctx, AV_LOG_ERROR,
                        "pps_id %u out of range\n", pps_id);
@@ -382,7 +732,7 @@ static inline int parse_nal_units(AVCodecParserContext *s,
             if (p->ps.sps->ref_frame_count <= 1 && p->ps.pps->ref_count[0] <= 1 && s->pict_type == AV_PICTURE_TYPE_I)
                 s->key_frame = 1;
 
-            p->poc.frame_num = get_bits(&nal.gb, sps->log2_max_frame_num);
+            p->poc.frame_num = get_bits(&nal->gb, sps->log2_max_frame_num);
 
             s->coded_width  = 16 * sps->mb_width;
             s->coded_height = 16 * sps->mb_height;
@@ -419,158 +769,50 @@ static inline int parse_nal_units(AVCodecParserContext *s,
             if (sps->frame_mbs_only_flag) {
                 p->picture_structure = PICT_FRAME;
             } else {
-                if (get_bits1(&nal.gb)) { // field_pic_flag
-                    p->picture_structure = PICT_TOP_FIELD + get_bits1(&nal.gb); // bottom_field_flag
+                if (get_bits1(&nal->gb)) { // field_pic_flag
+                    p->picture_structure = PICT_TOP_FIELD + get_bits1(&nal->gb); // bottom_field_flag
                 } else {
                     p->picture_structure = PICT_FRAME;
                 }
             }
 
-            if (nal.type == H264_NAL_IDR_SLICE)
-                get_ue_golomb_long(&nal.gb); /* idr_pic_id */
+            if (p->picture_structure == PICT_FRAME) {
+                p->curr_pic_num = p->poc.frame_num;
+                p->max_pic_num  = 1 << sps->log2_max_frame_num;
+            } else {
+                p->curr_pic_num = 2 * p->poc.frame_num + 1;
+                p->max_pic_num  = 1 << (sps->log2_max_frame_num + 1);
+            }
+            if (nal->type == H264_NAL_IDR_SLICE)
+                get_ue_golomb_long(&nal->gb); /* idr_pic_id */
             if (sps->poc_type == 0) {
-                p->poc.poc_lsb = get_bits(&nal.gb, sps->log2_max_poc_lsb);
+                p->poc.poc_lsb = get_bits(&nal->gb, sps->log2_max_poc_lsb);
 
                 if (p->ps.pps->pic_order_present == 1 &&
                     p->picture_structure == PICT_FRAME)
-                    p->poc.delta_poc_bottom = get_se_golomb(&nal.gb);
+                    p->poc.delta_poc_bottom = get_se_golomb(&nal->gb);
             }
 
             if (sps->poc_type == 1 &&
                 !sps->delta_pic_order_always_zero_flag) {
-                p->poc.delta_poc[0] = get_se_golomb(&nal.gb);
+                p->poc.delta_poc[0] = get_se_golomb(&nal->gb);
 
                 if (p->ps.pps->pic_order_present == 1 &&
                     p->picture_structure == PICT_FRAME)
-                    p->poc.delta_poc[1] = get_se_golomb(&nal.gb);
+                    p->poc.delta_poc[1] = get_se_golomb(&nal->gb);
             }
 
-            /* Decode POC of this picture.
-             * The prev_ values needed for decoding POC of the next picture are not set here. */
-            field_poc[0] = field_poc[1] = INT_MAX;
-            ret = ff_h264_init_poc(field_poc, &s->output_picture_number, sps,
-                             &p->poc, p->picture_structure, nal.ref_idc);
-            if (ret < 0)
+            // TODO move the other half of the slice-parsing code into this function
+            ret = parse_slice(s, avctx, nal);
+            if (ret != 0) {
                 goto fail;
-
-            /* Continue parsing to check if MMCO_RESET is present.
-             * FIXME: MMCO_RESET could appear in non-first slice.
-             *        Maybe, we should parse all undisposable non-IDR slice of this
-             *        picture until encountering MMCO_RESET in a slice of it. */
-            if (nal.ref_idc && nal.type != H264_NAL_IDR_SLICE) {
-                got_reset = scan_mmco_reset(s, &nal.gb, avctx);
-                if (got_reset < 0)
-                    goto fail;
             }
-
-            /* Set up the prev_ values for decoding POC of the next picture. */
-            p->poc.prev_frame_num        = got_reset ? 0 : p->poc.frame_num;
-            p->poc.prev_frame_num_offset = got_reset ? 0 : p->poc.frame_num_offset;
-            if (nal.ref_idc != 0) {
-                if (!got_reset) {
-                    p->poc.prev_poc_msb = p->poc.poc_msb;
-                    p->poc.prev_poc_lsb = p->poc.poc_lsb;
-                } else {
-                    p->poc.prev_poc_msb = 0;
-                    p->poc.prev_poc_lsb =
-                        p->picture_structure == PICT_BOTTOM_FIELD ? 0 : field_poc[0];
-                }
-            }
-
-            if (p->sei.picture_timing.present) {
-                ret = ff_h264_sei_process_picture_timing(&p->sei.picture_timing,
-                                                         sps, avctx);
-                if (ret < 0) {
-                    av_log(avctx, AV_LOG_ERROR, "Error processing the picture timing SEI\n");
-                    p->sei.picture_timing.present = 0;
-                }
-            }
-
-            if (sps->pic_struct_present_flag && p->sei.picture_timing.present) {
-                switch (p->sei.picture_timing.pic_struct) {
-                case H264_SEI_PIC_STRUCT_TOP_FIELD:
-                case H264_SEI_PIC_STRUCT_BOTTOM_FIELD:
-                    s->repeat_pict = 0;
-                    break;
-                case H264_SEI_PIC_STRUCT_FRAME:
-                case H264_SEI_PIC_STRUCT_TOP_BOTTOM:
-                case H264_SEI_PIC_STRUCT_BOTTOM_TOP:
-                    s->repeat_pict = 1;
-                    break;
-                case H264_SEI_PIC_STRUCT_TOP_BOTTOM_TOP:
-                case H264_SEI_PIC_STRUCT_BOTTOM_TOP_BOTTOM:
-                    s->repeat_pict = 2;
-                    break;
-                case H264_SEI_PIC_STRUCT_FRAME_DOUBLING:
-                    s->repeat_pict = 3;
-                    break;
-                case H264_SEI_PIC_STRUCT_FRAME_TRIPLING:
-                    s->repeat_pict = 5;
-                    break;
-                default:
-                    s->repeat_pict = p->picture_structure == PICT_FRAME ? 1 : 0;
-                    break;
-                }
-            } else {
-                s->repeat_pict = p->picture_structure == PICT_FRAME ? 1 : 0;
-            }
-
-            if (p->picture_structure == PICT_FRAME) {
-                s->picture_structure = AV_PICTURE_STRUCTURE_FRAME;
-                if (sps->pic_struct_present_flag && p->sei.picture_timing.present) {
-                    switch (p->sei.picture_timing.pic_struct) {
-                    case H264_SEI_PIC_STRUCT_TOP_BOTTOM:
-                    case H264_SEI_PIC_STRUCT_TOP_BOTTOM_TOP:
-                        s->field_order = AV_FIELD_TT;
-                        break;
-                    case H264_SEI_PIC_STRUCT_BOTTOM_TOP:
-                    case H264_SEI_PIC_STRUCT_BOTTOM_TOP_BOTTOM:
-                        s->field_order = AV_FIELD_BB;
-                        break;
-                    default:
-                        s->field_order = AV_FIELD_PROGRESSIVE;
-                        break;
-                    }
-                } else {
-                    if (field_poc[0] < field_poc[1])
-                        s->field_order = AV_FIELD_TT;
-                    else if (field_poc[0] > field_poc[1])
-                        s->field_order = AV_FIELD_BB;
-                    else
-                        s->field_order = AV_FIELD_PROGRESSIVE;
-                }
-            } else {
-                if (p->picture_structure == PICT_TOP_FIELD)
-                    s->picture_structure = AV_PICTURE_STRUCTURE_TOP_FIELD;
-                else
-                    s->picture_structure = AV_PICTURE_STRUCTURE_BOTTOM_FIELD;
-                if (p->poc.frame_num == p->last_frame_num &&
-                    p->last_picture_structure != AV_PICTURE_STRUCTURE_UNKNOWN &&
-                    p->last_picture_structure != AV_PICTURE_STRUCTURE_FRAME &&
-                    p->last_picture_structure != s->picture_structure) {
-                    if (p->last_picture_structure == AV_PICTURE_STRUCTURE_TOP_FIELD)
-                        s->field_order = AV_FIELD_TT;
-                    else
-                        s->field_order = AV_FIELD_BB;
-                } else {
-                    s->field_order = AV_FIELD_UNKNOWN;
-                }
-                p->last_picture_structure = s->picture_structure;
-                p->last_frame_num = p->poc.frame_num;
-            }
-            if (sps->timing_info_present_flag) {
-                int64_t den = sps->time_scale;
-                if (p->sei.common.unregistered.x264_build < 44U)
-                    den *= 2;
-                av_reduce(&avctx->framerate.den, &avctx->framerate.num,
-                          sps->num_units_in_tick * 2, den, 1 << 30);
-            }
-
-            av_freep(&rbsp.rbsp_buffer);
-            return 0; /* no need to evaluate the rest */
+            nal->slice_header_len_bits = nal->gb.index;
+            break;
         }
+        nal_index++;
     }
-    if (q264) {
+    if (q264 || picture_found) {
         av_freep(&rbsp.rbsp_buffer);
         return 0;
     }

--- a/libavcodec/internal.h
+++ b/libavcodec/internal.h
@@ -185,6 +185,11 @@ int ff_alloc_timecode_sei(const AVFrame *frame, AVRational rate, size_t prefix_l
                      void **data, size_t *sei_size);
 
 /**
+ * Returns an array of H2645NALs
+ */
+void* avpriv_h264_extract_nals(AVCodecParserContext *s);
+
+/**
  * Get an estimated video bitrate based on frame size, frame rate and coded
  * bits per pixel.
  */

--- a/libavformat/dashenc.c
+++ b/libavformat/dashenc.c
@@ -26,7 +26,13 @@
 #if HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#if CONFIG_GCRYPT
+#include <gcrypt.h>
+#elif CONFIG_OPENSSL
+#include <openssl/rand.h>
+#endif
 
+#include "libavutil/aes.h"
 #include "libavutil/avassert.h"
 #include "libavutil/avutil.h"
 #include "libavutil/avstring.h"
@@ -35,6 +41,7 @@
 #include "libavutil/mathematics.h"
 #include "libavutil/mem.h"
 #include "libavutil/opt.h"
+#include "libavutil/random_seed.h"
 #include "libavutil/parseutils.h"
 #include "libavutil/rational.h"
 #include "libavutil/time.h"
@@ -57,6 +64,10 @@
 #include "url.h"
 #include "vpcc.h"
 #include "dash.h"
+
+#define BLOCKSIZE 16
+#define KEYSIZE  16
+static const char AES_KEY_OUT_PATH[] = "key.bin";
 
 typedef enum {
     SEGMENT_TYPE_AUTO = 0,
@@ -145,6 +156,14 @@ typedef struct OutputStream {
     int64_t gop_size;
     AVRational sar;
     int coding_dependency;
+
+    struct AVAES *aes_context;
+    int aes_encrypt;
+    uint8_t aes_iv[KEYSIZE];
+    uint8_t aes_pad[BLOCKSIZE];
+    int aes_pad_len;
+    uint8_t *aes_write_buf;
+    unsigned int aes_write_buf_size;
 } OutputStream;
 
 typedef struct DASHContext {
@@ -204,6 +223,19 @@ typedef struct DASHContext {
     AVRational min_playback_rate;
     AVRational max_playback_rate;
     int64_t update_period;
+
+    // Pass-through options to movenc -PTT
+    char *encryption_scheme_str;
+    uint8_t *encryption_key;
+    uint8_t *encryption_kid;
+    uint8_t *encryption_iv;
+
+    int aes_encrypt;
+    uint8_t aes_iv[KEYSIZE];
+    char *aes_iv_hex;
+    uint8_t aes_key[KEYSIZE];
+    char *aes_key_hex;
+    char *aes_key_url;
 } DASHContext;
 
 static const struct codec_string {
@@ -217,6 +249,70 @@ static const struct codec_string {
     { AV_CODEC_ID_FLAC, "flac" },
     { AV_CODEC_ID_NONE }
 };
+
+static int aes_init(DASHContext *c, OutputStream *os) {
+    if (!c->aes_encrypt) return 0;
+    av_assert0(os->aes_context == NULL);
+    int ret = 0;
+    if ((os->aes_context = av_aes_alloc()) == NULL)
+        return AVERROR(ENOMEM);
+    if ((ret = av_aes_init(os->aes_context, c->aes_key, BLOCKSIZE * 8, 0)) < 0)
+        return ret;
+    os->aes_encrypt = 1;
+    memcpy(os->aes_iv, c->aes_iv, sizeof(os->aes_iv));
+    return 0;
+}
+
+static void aes_free(OutputStream *os) {
+    if (!os->aes_encrypt) return;
+    if (os->aes_context) {
+        uint8_t out_buf[BLOCKSIZE];
+        int pad = BLOCKSIZE - os->aes_pad_len;
+
+        memset(&os->aes_pad[os->aes_pad_len], pad, pad);
+        av_aes_crypt(os->aes_context, out_buf, os->aes_pad, 1, os->aes_iv, 0);
+        if (os->out)
+            avio_write(os->out, out_buf, BLOCKSIZE);
+    }
+    av_freep(&os->aes_context);
+    av_freep(&os->aes_write_buf);
+    os->aes_encrypt = 0;
+    os->aes_pad_len = 0;
+    os->aes_write_buf_size = 0;
+}
+
+static int dashenc_avio_write(OutputStream *os, const unsigned char *buf, int size) {
+    if (!os->aes_encrypt) {
+        avio_write(os->out, buf, size);
+        return size;
+    }
+
+    int total_size = size + os->aes_pad_len;
+    int pad_len = total_size % BLOCKSIZE;
+    int out_size = total_size - pad_len;
+    int blocks = out_size / BLOCKSIZE;
+
+    if (out_size) {
+        av_fast_malloc(&os->aes_write_buf, &os->aes_write_buf_size, out_size);
+        if (!os->aes_write_buf)
+            return AVERROR(ENOMEM);
+        if (os->aes_pad_len) {
+            memcpy(&os->aes_pad[os->aes_pad_len], buf, BLOCKSIZE - os->aes_pad_len);
+            av_aes_crypt(os->aes_context, os->aes_write_buf, os->aes_pad, 1, os->aes_iv, 0);
+            blocks--;
+        }
+        av_aes_crypt(os->aes_context,
+                     &os->aes_write_buf[os->aes_pad_len ? BLOCKSIZE : 0],
+                     &buf[os->aes_pad_len ? BLOCKSIZE - os->aes_pad_len : 0],
+                     blocks, os->aes_iv, 0);
+        avio_write(os->out, os->aes_write_buf, out_size);
+        memcpy(os->aes_pad, &buf[size - pad_len], pad_len);
+    } else {
+        memcpy(&os->aes_pad[os->aes_pad_len], buf, size);
+    }
+    os->aes_pad_len = pad_len;
+    return size;
+}
 
 static int dashenc_io_open(AVFormatContext *s, AVIOContext **pb, char *filename,
                            AVDictionary **options) {
@@ -455,7 +551,7 @@ static int flush_dynbuf(DASHContext *c, OutputStream *os, int *range_length)
         *range_length = avio_close_dyn_buf(os->ctx->pb, &buffer);
         os->ctx->pb = NULL;
         if (os->out)
-            avio_write(os->out, buffer + os->written_len, *range_length - os->written_len);
+            dashenc_avio_write(os, buffer + os->written_len, *range_length - os->written_len);
         os->written_len = 0;
         av_free(buffer);
 
@@ -541,6 +637,13 @@ static void write_hls_media_playlist(OutputStream *os, AVFormatContext *s,
     ff_hls_write_playlist_header(c->m3u8_out, 6, -1, target_duration,
                                  start_number, PLAYLIST_TYPE_NONE, 0);
 
+    if (c->aes_encrypt) {
+        avio_printf(c->m3u8_out, "#EXT-X-KEY:METHOD=AES-128,URI=\"%s\"", c->aes_key_url);
+        if (*c->aes_iv_hex)
+            avio_printf(c->m3u8_out, ",IV=0x%s", c->aes_iv_hex);
+        avio_printf(c->m3u8_out, "\n");
+    }
+
     ff_hls_write_init_file(c->m3u8_out, os->initfile, c->single_file,
                            os->init_range_length, os->init_start_pos);
 
@@ -590,6 +693,7 @@ static int flush_init_segment(AVFormatContext *s, OutputStream *os)
     if (!c->single_file) {
         char filename[1024];
         snprintf(filename, sizeof(filename), "%s%s", c->dirname, os->initfile);
+        aes_free(os);
         dashenc_io_close(s, &os->out, filename);
     }
     return 0;
@@ -629,6 +733,7 @@ static void dash_free(AVFormatContext *s)
         av_freep(&os->single_file_name);
         av_freep(&os->init_seg_name);
         av_freep(&os->media_seg_name);
+        aes_free(os);
     }
     av_freep(&c->streams);
 
@@ -1370,6 +1475,85 @@ static int dict_copy_entry(AVDictionary **dst, const AVDictionary *src, const ch
     return 0;
 }
 
+static int randomize(uint8_t *buf, int len)
+{
+#if CONFIG_GCRYPT
+    gcry_randomize(buf, len, GCRY_VERY_STRONG_RANDOM);
+    return 0;
+#elif CONFIG_OPENSSL
+    if (RAND_bytes(buf, len))
+        return 0;
+#else
+    for (int i = 0; i < len; i++) {
+        buf[i] = av_get_random_seed();
+    }
+    return 0;
+#endif
+    return AVERROR(EINVAL);
+}
+
+// Compare to hlsenc.c::do_encrypt() -PTT
+static int init_crypto(AVFormatContext *s)
+{
+    DASHContext *c = s->priv_data;
+    int ret = 0;
+    int write_key_file = 0;
+
+    const int iv_len = sizeof(c->aes_iv);
+    const int iv_hex_len = iv_len * 2;
+    if (!c->aes_iv_hex || strlen(c->aes_iv_hex) == 0) {
+        if ((ret = randomize(c->aes_iv, iv_len)) < 0) {
+            av_log(s, AV_LOG_ERROR, "Failed to generate an AES IV\n");
+            return ret;
+        }
+        c->aes_iv_hex = av_mallocz(iv_hex_len + 1);
+        ff_data_to_hex(c->aes_iv_hex, c->aes_iv, iv_len, 0);
+        c->aes_iv_hex[iv_hex_len] = '\0';
+    } else {
+        if (strlen(c->aes_iv_hex) != iv_hex_len) {
+            av_log(s, AV_LOG_ERROR, "The AES IV must be 32 hex characters\n");
+            return ret;
+        }
+        ff_hex_to_data(c->aes_iv, c->aes_iv_hex);
+    }
+
+    const int key_len = sizeof(c->aes_key);
+    const int key_hex_len = key_len * 2;
+    if (!c->aes_key_hex || strlen(c->aes_key_hex) == 0) {
+        if ((ret = randomize(c->aes_key, key_len)) < 0) {
+            av_log(s, AV_LOG_ERROR, "Failed to generate an AES key\n");
+            return ret;
+        }
+        c->aes_key_hex = av_mallocz(key_hex_len + 1);
+        ff_data_to_hex(c->aes_key_hex, c->aes_key, key_len, 0);
+        c->aes_key_hex[key_hex_len] = '\0';
+        write_key_file = 1;
+    } else {
+        if (strlen(c->aes_key_hex) != key_hex_len) {
+            av_log(s, AV_LOG_ERROR, "The AES key must be 32 hex characters\n");
+            return ret;
+        }
+        ff_hex_to_data(c->aes_key, c->aes_key_hex);
+    }
+
+    if (!c->aes_key_url || strlen(c->aes_key_url) == 0) {
+        c->aes_key_url = av_mallocz(sizeof(AES_KEY_OUT_PATH));
+        av_strlcpy(c->aes_key_url, AES_KEY_OUT_PATH, sizeof(AES_KEY_OUT_PATH));
+        write_key_file = 1;
+    }
+
+    if (write_key_file) {
+        AVIOContext *pb = NULL;
+        if ((ret = s->io_open(s, &pb, AES_KEY_OUT_PATH, AVIO_FLAG_WRITE, NULL)) < 0)
+            return ret;
+        avio_seek(pb, 0, SEEK_CUR);
+        avio_write(pb, c->aes_key, KEYSIZE);
+        ff_format_io_close(s, &pb);
+    }
+
+    return 0;
+}
+
 static int dash_init(AVFormatContext *s)
 {
     DASHContext *c = s->priv_data;
@@ -1481,6 +1665,10 @@ static int dash_init(AVFormatContext *s)
     if ((ret = init_segment_types(s)) < 0)
         return ret;
 
+    if (c->aes_encrypt) {
+        if ((ret = init_crypto(s)) < 0) return ret;
+    }
+
     for (i = 0; i < s->nb_streams; i++) {
         OutputStream *os = &c->streams[i];
         AdaptationSet *as = &c->as[os->as_idx - 1];
@@ -1589,6 +1777,8 @@ static int dash_init(AVFormatContext *s)
         av_dict_free(&opts);
         if (ret < 0)
             return ret;
+        if ((ret = aes_init(c, os)) != 0)
+            return ret;
         os->init_start_pos = 0;
 
         av_dict_copy(&opts, c->format_options, 0);
@@ -1645,6 +1835,19 @@ static int dash_init(AVFormatContext *s)
                 av_dict_set_int(&opts, "frag_duration", os->frag_duration, 0);
             if (c->write_prft)
                 av_dict_set(&opts, "write_prft", "wallclock", 0);
+
+            if (c->encryption_scheme_str != NULL) {
+                av_dict_set(&opts, "encryption_scheme", c->encryption_scheme_str, 0);
+            }
+            if (c->encryption_key != NULL) {
+                av_dict_set(&opts, "encryption_key", c->encryption_key, 0);
+            }
+            if (c->encryption_kid != NULL) {
+                av_dict_set(&opts, "encryption_kid", c->encryption_kid, 0);
+            }
+            if (c->encryption_iv != NULL) {
+                av_dict_set(&opts, "encryption_iv", c->encryption_iv, 0);
+            }
         } else {
             av_dict_set_int(&opts, "cluster_time_limit", c->seg_duration / 1000, 0);
             av_dict_set_int(&opts, "cluster_size_limit", 5 * 1024 * 1024, 0); // set a large cluster size limit
@@ -1961,6 +2164,7 @@ static int dash_flush(AVFormatContext *s, int final, int stream)
         if (c->single_file) {
             find_index_range(s, os->full_path, os->pos, &index_length);
         } else {
+            aes_free(os);
             dashenc_io_close(s, &os->out, os->temp_path);
 
             if (use_rename) {
@@ -2266,6 +2470,9 @@ static int dash_write_packet(AVFormatContext *s, AVPacket *pkt)
             write_manifest(s, 0);
         }
 
+        if ((ret = aes_init(c, os)) != 0)
+            return ret;
+
         if (c->lhls) {
             char *prefetch_url = use_rename ? NULL : os->filename;
             write_hls_media_playlist(os, s, pkt->stream_index, 0, prefetch_url);
@@ -2279,7 +2486,7 @@ static int dash_write_packet(AVFormatContext *s, AVPacket *pkt)
         avio_flush(os->ctx->pb);
         len = avio_get_dyn_buf (os->ctx->pb, &buf);
         if (os->out) {
-            avio_write(os->out, buf + os->written_len, len - os->written_len);
+            dashenc_avio_write(os, buf + os->written_len, len - os->written_len);
             avio_flush(os->out);
         }
         os->written_len = len;
@@ -2399,6 +2606,14 @@ static const AVOption options[] = {
     { "utc_timing_url", "URL of the page that will return the UTC timestamp in ISO format", OFFSET(utc_timing_url), AV_OPT_TYPE_STRING, { 0 }, 0, 0, E },
     { "window_size", "number of segments kept in the manifest", OFFSET(window_size), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, INT_MAX, E },
     { "write_prft", "Write producer reference time element", OFFSET(write_prft), AV_OPT_TYPE_BOOL, {.i64 = -1}, -1, 1, E},
+    { "encryption_scheme", "Configures the Common Encryption scheme, allowed values are none, cenc-aes-ctr, cenc-aes-cbc-pattern", OFFSET(encryption_scheme_str), AV_OPT_TYPE_STRING, {.str = NULL}, .flags = AV_OPT_FLAG_ENCODING_PARAM },
+    { "encryption_key", "The media encryption key (hex)", OFFSET(encryption_key), AV_OPT_TYPE_STRING, {.str = NULL}, .flags = AV_OPT_FLAG_ENCODING_PARAM },
+    { "encryption_kid", "The media encryption key identifier (hex)", OFFSET(encryption_kid), AV_OPT_TYPE_STRING, {.str = NULL}, .flags = AV_OPT_FLAG_ENCODING_PARAM },
+    { "encryption_iv", "Specify the media encryption iv (hex)", OFFSET(encryption_iv), AV_OPT_TYPE_STRING, {.str = NULL}, .flags = AV_OPT_FLAG_ENCODING_PARAM },
+    { "hls_enc", "enable AES128 encryption support", OFFSET(aes_encrypt), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, E},
+    { "hls_enc_key", "hex-coded 16 byte key to encrypt the segments", OFFSET(aes_key_hex), AV_OPT_TYPE_STRING, .flags = E},
+    { "hls_enc_key_url", "url to access the key to decrypt the segments", OFFSET(aes_key_url), AV_OPT_TYPE_STRING, {.str = NULL}, 0, 0, E},
+    { "hls_enc_iv", "hex-coded 16 byte initialization vector", OFFSET(aes_iv_hex), AV_OPT_TYPE_STRING, .flags = E},
     { NULL },
 };
 

--- a/libavformat/isom.h
+++ b/libavformat/isom.h
@@ -123,6 +123,12 @@ typedef struct MOVSbgp {
     unsigned int index;
 } MOVSbgp;
 
+typedef enum {
+    MOV_ENC_NONE = 0,
+    MOV_ENC_CENC_AES_CTR,
+    MOV_ENC_CENC_AES_CBC_PATTERN
+} MOVEncryptionScheme;
+
 typedef struct MOVEncryptionIndex {
     // Individual encrypted samples.  If there are no elements, then the default
     // settings will be used.

--- a/libavformat/movenc.c
+++ b/libavformat/movenc.c
@@ -77,9 +77,10 @@
 static const AVOption options[] = {
     { "brand",    "Override major brand", offsetof(MOVMuxContext, major_brand),   AV_OPT_TYPE_STRING, {.str = NULL}, .flags = AV_OPT_FLAG_ENCODING_PARAM },
     { "empty_hdlr_name", "write zero-length name string in hdlr atoms within mdia and minf atoms", offsetof(MOVMuxContext, empty_hdlr_name), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, AV_OPT_FLAG_ENCODING_PARAM},
+    { "encryption_iv", "Specify the media encryption iv (hex)", offsetof(MOVMuxContext, encryption_iv), AV_OPT_TYPE_BINARY, .flags = AV_OPT_FLAG_ENCODING_PARAM },
     { "encryption_key", "The media encryption key (hex)", offsetof(MOVMuxContext, encryption_key), AV_OPT_TYPE_BINARY, .flags = AV_OPT_FLAG_ENCODING_PARAM },
     { "encryption_kid", "The media encryption key identifier (hex)", offsetof(MOVMuxContext, encryption_kid), AV_OPT_TYPE_BINARY, .flags = AV_OPT_FLAG_ENCODING_PARAM },
-    { "encryption_scheme",    "Configures the encryption scheme, allowed values are none, cenc-aes-ctr", offsetof(MOVMuxContext, encryption_scheme_str),   AV_OPT_TYPE_STRING, {.str = NULL}, .flags = AV_OPT_FLAG_ENCODING_PARAM },
+    { "encryption_scheme", "Configures the Common Encryption scheme, allowed values are none, cenc-aes-ctr, cenc-aes-cbc-pattern", offsetof(MOVMuxContext, encryption_scheme_str), AV_OPT_TYPE_STRING, {.str = NULL}, .flags = AV_OPT_FLAG_ENCODING_PARAM },
     { "frag_duration", "Maximum fragment duration", offsetof(MOVMuxContext, max_fragment_duration), AV_OPT_TYPE_INT, {.i64 = 0}, 0, INT_MAX, AV_OPT_FLAG_ENCODING_PARAM},
     { "frag_interleave", "Interleave samples within fragments (max number of consecutive samples, lower is tighter interleaving, but with more overhead)", offsetof(MOVMuxContext, frag_interleave), AV_OPT_TYPE_INT, {.i64 = 0}, 0, INT_MAX, AV_OPT_FLAG_ENCODING_PARAM },
     { "frag_size", "Maximum fragment size", offsetof(MOVMuxContext, max_fragment_size), AV_OPT_TYPE_INT, {.i64 = 0}, 0, INT_MAX, AV_OPT_FLAG_ENCODING_PARAM},
@@ -3317,7 +3318,8 @@ static int mov_write_stbl_tag(AVFormatContext *s, AVIOContext *pb, MOVMuxContext
     mov_write_stsc_tag(pb, track);
     mov_write_stsz_tag(pb, track);
     mov_write_stco_tag(pb, track);
-    if (track->cenc.aes_ctr && !(mov->flags & FF_MOV_FLAG_FRAGMENT)) {
+    if (track->cenc.encryption_scheme != MOV_ENC_NONE && !(mov->flags & FF_MOV_FLAG_FRAGMENT)) {
+        ff_mov_cenc_write_senc_tag(&track->cenc, pb, 0);
         ff_mov_cenc_write_stbl_atoms(&track->cenc, pb, 0);
     }
     if (track->par->codec_id == AV_CODEC_ID_OPUS || track->par->codec_id == AV_CODEC_ID_AAC) {
@@ -5645,8 +5647,10 @@ static int mov_write_traf_tag(AVIOContext *pb, MOVMuxContext *mov,
         }
     }
 
-    if (track->cenc.aes_ctr && (mov->flags & FF_MOV_FLAG_FRAGMENT))
+    if (track->cenc.encryption_scheme != MOV_ENC_NONE) {
+        ff_mov_cenc_write_senc_tag(&track->cenc, pb, moof_offset);
         ff_mov_cenc_write_stbl_atoms(&track->cenc, pb, moof_offset);
+    }
 
     return update_size(pb, pos);
 }
@@ -5668,7 +5672,7 @@ static int mov_write_moof_tag_internal(AVIOContext *pb, MOVMuxContext *mov,
             continue;
         if (!track->entry)
             continue;
-        if (track->cenc.aes_ctr && (mov->flags & FF_MOV_FLAG_FRAGMENT))
+        if (track->cenc.encryption_scheme != MOV_ENC_NONE && (mov->flags & FF_MOV_FLAG_FRAGMENT))
             mov_write_pssh_tag(pb, track->st);
         mov_write_traf_tag(pb, mov, track, pos, moof_size);
     }
@@ -6608,6 +6612,8 @@ static int mov_flush_fragment(AVFormatContext *s, int force)
 
         avio_write(s->pb, buf, buf_size);
         av_free(buf);
+
+        ff_mov_cenc_auxiliary_info_reset(&track->cenc);
     }
 
     mov->mdat_size = 0;
@@ -6829,8 +6835,8 @@ int ff_mov_write_packet(AVFormatContext *s, AVPacket *pkt)
                 return ret;
             avio_write(pb, reformatted_data, size);
         } else {
-            if (trk->cenc.aes_ctr) {
-                size = ff_mov_cenc_avc_parse_nal_units(&trk->cenc, pb, pkt->data, size);
+            if (trk->cenc.encryption_scheme != MOV_ENC_NONE) {
+                size = ff_mov_cenc_avc_parse_nal_units(s, &trk->cenc, pb, pkt);
                 if (size < 0) {
                     ret = size;
                     goto err;
@@ -6850,8 +6856,8 @@ int ff_mov_write_packet(AVFormatContext *s, AVPacket *pkt)
                 return ret;
             avio_write(pb, reformatted_data, size);
         } else {
-            if (trk->cenc.aes_ctr) {
-                size = ff_mov_cenc_avc_parse_nal_units(&trk->cenc, pb, pkt->data, size);
+            if (trk->cenc.encryption_scheme != MOV_ENC_NONE) {
+                size = ff_mov_cenc_avc_parse_nal_units(s, &trk->cenc, pb, pkt);
                 if (size < 0) {
                     ret = size;
                     goto err;
@@ -6872,7 +6878,7 @@ int ff_mov_write_packet(AVFormatContext *s, AVPacket *pkt)
         } else {
             size = ff_vvc_annexb2mp4(pb, pkt->data, pkt->size, 0, NULL);
         }
-    } else if (par->codec_id == AV_CODEC_ID_AV1 && !trk->cenc.aes_ctr) {
+    } else if (par->codec_id == AV_CODEC_ID_AV1 && trk->cenc.encryption_scheme == MOV_ENC_NONE) {
         if (trk->hint_track >= 0 && trk->hint_track < mov->nb_tracks) {
             ret = ff_av1_filter_obus_buf(pkt->data, &reformatted_data,
                                          &size, &offset);
@@ -6917,15 +6923,11 @@ int ff_mov_write_packet(AVFormatContext *s, AVPacket *pkt)
 
         avio_write(s->pb, pkt->data, pkt->size);
     } else {
-        if (trk->cenc.aes_ctr) {
-            uint8_t *extradata = trk->extradata[trk->last_stsd_index];
-            int extradata_size = trk->extradata_size[trk->last_stsd_index];
-            if (par->codec_id == AV_CODEC_ID_H264 && extradata_size > 4) {
-                int nal_size_length = (extradata[4] & 0x3) + 1;
-                ret = ff_mov_cenc_avc_write_nal_units(s, &trk->cenc, nal_size_length, pb, pkt->data, size);
-            } else if(par->codec_id == AV_CODEC_ID_HEVC && extradata_size > 21) {
-                int nal_size_length = (extradata[21] & 0x3) + 1;
-                ret = ff_mov_cenc_avc_write_nal_units(s, &trk->cenc, nal_size_length, pb, pkt->data, size);
+        if (trk->cenc.encryption_scheme != MOV_ENC_NONE) {
+            if (par->codec_id == AV_CODEC_ID_H264 && par->extradata_size > 4) {
+                ret = ff_mov_cenc_h2645_write_nal_units(s, &trk->cenc, pb, pkt);
+            } else if(par->codec_id == AV_CODEC_ID_HEVC && par->extradata_size > 21) {
+                ret = ff_mov_cenc_h2645_write_nal_units(s, &trk->cenc, pb, pkt);
             } else if(par->codec_id == AV_CODEC_ID_VVC) {
                 ret = AVERROR_PATCHWELCOME;
             } else if(par->codec_id == AV_CODEC_ID_AV1) {
@@ -6939,7 +6941,7 @@ int ff_mov_write_packet(AVFormatContext *s, AVPacket *pkt)
                 ret = ff_mov_cenc_write_packet(&trk->cenc, pb, pkt->data, size);
             }
 
-            if (ret) {
+            if (ret < 0) {
                 goto err;
             }
         } else {
@@ -8062,15 +8064,23 @@ static int mov_init(AVFormatContext *s)
                     mov->encryption_key_len, AES_CTR_KEY_SIZE);
                 return AVERROR(EINVAL);
             }
+        } else if (strcmp(mov->encryption_scheme_str, "cenc-aes-cbc-pattern") == 0) {
+            mov->encryption_scheme = MOV_ENC_CENC_AES_CBC_PATTERN;
 
-            if (mov->encryption_kid_len != CENC_KID_SIZE) {
-                av_log(s, AV_LOG_ERROR, "Invalid encryption kid len %d expected %d\n",
-                    mov->encryption_kid_len, CENC_KID_SIZE);
+            if (mov->encryption_key_len != 16) { // 9.4.3 of the ISO CENC spec
+                av_log(s, AV_LOG_ERROR, "Invalid encryption key len %d expected 16\n",
+                    mov->encryption_key_len);
                 return AVERROR(EINVAL);
             }
         } else {
             av_log(s, AV_LOG_ERROR, "unsupported encryption scheme %s\n",
                 mov->encryption_scheme_str);
+            return AVERROR(EINVAL);
+        }
+
+        if (mov->encryption_kid_len != CENC_KID_SIZE) {
+            av_log(s, AV_LOG_ERROR, "Invalid encryption kid len %d expected %d\n",
+                mov->encryption_kid_len, CENC_KID_SIZE);
             return AVERROR(EINVAL);
         }
     }
@@ -8287,8 +8297,10 @@ static int mov_init(AVFormatContext *s)
 
         avpriv_set_pts_info(st, 64, 1, track->timescale);
 
-        if (mov->encryption_scheme == MOV_ENC_CENC_AES_CTR) {
-            ret = ff_mov_cenc_init(&track->cenc, mov->encryption_key,
+        if (mov->encryption_scheme != MOV_ENC_NONE) {
+            ret = ff_mov_cenc_init(&track->cenc, track->par,
+                mov->encryption_scheme, mov->encryption_key,
+                mov->encryption_iv, mov->encryption_iv_len,
                 (track->par->codec_id == AV_CODEC_ID_H264 || track->par->codec_id == AV_CODEC_ID_HEVC ||
                  track->par->codec_id == AV_CODEC_ID_VVC || track->par->codec_id == AV_CODEC_ID_AV1),
                  track->par->codec_id, s->flags & AVFMT_FLAG_BITEXACT);

--- a/libavformat/movenc.h
+++ b/libavformat/movenc.h
@@ -187,11 +187,6 @@ typedef struct MOVTrack {
 } MOVTrack;
 
 typedef enum {
-    MOV_ENC_NONE = 0,
-    MOV_ENC_CENC_AES_CTR,
-} MOVEncryptionScheme;
-
-typedef enum {
     MOV_PRFT_NONE = 0,
     MOV_PRFT_SRC_WALLCLOCK,
     MOV_PRFT_SRC_PTS,
@@ -250,6 +245,8 @@ typedef struct MOVMuxContext {
     int encryption_key_len;
     uint8_t *encryption_kid;
     int encryption_kid_len;
+    uint8_t *encryption_iv;
+    int encryption_iv_len;
 
     int use_stream_ids_as_track_ids;
     int track_ids_ok;

--- a/libavformat/movenccenc.c
+++ b/libavformat/movenccenc.c
@@ -22,12 +22,19 @@
 #include "libavcodec/av1_parse.h"
 #include "libavcodec/bytestream.h"
 #include "libavcodec/cbs_av1.h"
+#include "libavcodec/h2645_parse.h"
+#include "libavcodec/internal.h"
+#include "libavutil/aes.h"
+#include "libavutil/avassert.h"
 #include "libavutil/intreadwrite.h"
 #include "libavutil/mem.h"
+#include "libavutil/random_seed.h"
 #include "avio_internal.h"
 #include "movenc.h"
 #include "avc.h"
 #include "nal.h"
+
+#define AES_BLOCK_SIZE (16)
 
 static int auxiliary_info_alloc_size(MOVMuxCencContext* ctx, int size)
 {
@@ -46,7 +53,7 @@ static int auxiliary_info_alloc_size(MOVMuxCencContext* ctx, int size)
 }
 
 static int auxiliary_info_write(MOVMuxCencContext* ctx,
-                                         const uint8_t *buf_in, int size)
+                                const uint8_t *buf_in, int size)
 {
     int ret;
 
@@ -88,21 +95,50 @@ static int auxiliary_info_add_subsample(MOVMuxCencContext* ctx,
     return 0;
 }
 
+void ff_mov_cenc_auxiliary_info_reset(MOVMuxCencContext* ctx) {
+    ctx->auxiliary_info_size = 0;
+    ctx->auxiliary_info_entries = 0;
+}
+
 /**
  * Encrypt the input buffer and write using avio_write
+ *
+ * For AES-CBC, the block chain starting with MOVMuxCencContext->aes_cbc_iv is
+ * wholly contained in this function; i.e. the chain does not span multiple
+ * calls.
  */
 static void mov_cenc_write_encrypted(MOVMuxCencContext* ctx, AVIOContext *pb,
                                      const uint8_t *buf_in, int size)
 {
-    uint8_t chunk[4096];
+    uint8_t chunk[4000];
     const uint8_t* cur_pos = buf_in;
     int size_left = size;
-    int cur_size;
+    int cur_size, block_count, enc_size, remaining_size;
+    uint8_t aes_cbc_iv[AES_BLOCK_SIZE];
+
+    /* pattern encryption repeats every 10 blocks */
+    av_assert2(sizeof(chunk) % (AES_BLOCK_SIZE * 10) == 0);
+
+    if (ctx->encryption_scheme == MOV_ENC_CENC_AES_CBC_PATTERN) {
+        /* use constant IV and reset the chain for each sample/subsample */
+        memcpy(aes_cbc_iv, ctx->aes_cbc_iv, sizeof(aes_cbc_iv));
+    }
 
     while (size_left > 0) {
-        cur_size = FFMIN(size_left, sizeof(chunk));
-        av_aes_ctr_crypt(ctx->aes_ctr, chunk, cur_pos, cur_size);
-        avio_write(pb, chunk, cur_size);
+        cur_size = FFMIN((unsigned int)size_left, sizeof(chunk));
+        if (ctx->encryption_scheme == MOV_ENC_CENC_AES_CTR) {
+            av_aes_ctr_crypt(ctx->aes_ctr, chunk, cur_pos, cur_size);
+            avio_write(pb, chunk, cur_size);
+        } else { /* MOV_ENC_CENC_AES_CBC_PATTERN */
+            /* remaining data smaller than a full block remains unencrypted */
+            block_count = cur_size / AES_BLOCK_SIZE;
+            enc_size = block_count * AES_BLOCK_SIZE;
+            remaining_size = cur_size - enc_size;
+            /* same call for both pattern and full sample encryption */
+            av_aes_crypt(ctx->aes_cbc, chunk, cur_pos, block_count, aes_cbc_iv, 0);
+            avio_write(pb, chunk, enc_size);
+            avio_write(pb, cur_pos + enc_size, remaining_size);
+        }
         cur_pos += cur_size;
         size_left -= cur_size;
     }
@@ -113,14 +149,21 @@ static void mov_cenc_write_encrypted(MOVMuxCencContext* ctx, AVIOContext *pb,
  */
 static int mov_cenc_start_packet(MOVMuxCencContext* ctx)
 {
-    int ret;
+    int ret = 0;
 
-    /* write the iv */
-    ret = auxiliary_info_write(ctx, av_aes_ctr_get_iv(ctx->aes_ctr), AES_CTR_IV_SIZE);
-    if (ret) {
-        return ret;
+    /**
+     * write the iv
+     *
+     * omit for cbcs - the per-sample iv is zero when using a constant iv
+     */
+    if (ctx->encryption_scheme == MOV_ENC_CENC_AES_CTR) {
+        ret = auxiliary_info_write(ctx, av_aes_ctr_get_iv(ctx->aes_ctr), AES_CTR_IV_SIZE);
+        if (ret) {
+            return ret;
+        }
     }
 
+    /* subsample clear/protected data counts are not needed for full sample encryption */
     if (!ctx->use_subsamples) {
         return 0;
     }
@@ -142,15 +185,24 @@ static int mov_cenc_start_packet(MOVMuxCencContext* ctx)
 static int mov_cenc_end_packet(MOVMuxCencContext* ctx)
 {
     size_t new_alloc_size;
+    size_t sample_iv_size;
 
-    av_aes_ctr_increment_iv(ctx->aes_ctr);
-
-    if (!ctx->use_subsamples) {
-        ctx->auxiliary_info_entries++;
-        return 0;
+    if (ctx->encryption_scheme == MOV_ENC_CENC_AES_CTR) {
+        sample_iv_size = AES_CTR_IV_SIZE;
+        av_aes_ctr_increment_iv(ctx->aes_ctr);
+        if (!ctx->use_subsamples) {
+            ctx->auxiliary_info_entries++;
+            return 0;
+        }
+    } else { /* MOV_ENC_CENC_AES_CBC_PATTERN */
+        sample_iv_size = 0; /* constant iv */
+        if (!ctx->use_subsamples) {
+            /* no aux info needed */
+            return 0;
+        }
     }
 
-    /* add the auxiliary info entry size*/
+    /* add the auxiliary info entry size */
     if (ctx->auxiliary_info_entries >= ctx->auxiliary_info_sizes_alloc_size) {
         new_alloc_size = ctx->auxiliary_info_entries * 2 + 1;
         if (av_reallocp(&ctx->auxiliary_info_sizes, new_alloc_size)) {
@@ -160,10 +212,10 @@ static int mov_cenc_end_packet(MOVMuxCencContext* ctx)
         ctx->auxiliary_info_sizes_alloc_size = new_alloc_size;
     }
     ctx->auxiliary_info_sizes[ctx->auxiliary_info_entries] =
-        AES_CTR_IV_SIZE + ctx->auxiliary_info_size - ctx->auxiliary_info_subsample_start;
+        sample_iv_size + ctx->auxiliary_info_size - ctx->auxiliary_info_subsample_start;
     ctx->auxiliary_info_entries++;
 
-    /* update the subsample count*/
+    /* update the subsample count */
     AV_WB16(ctx->auxiliary_info + ctx->auxiliary_info_subsample_start, ctx->subsample_count);
 
     return 0;
@@ -194,36 +246,74 @@ int ff_mov_cenc_write_packet(MOVMuxCencContext* ctx, AVIOContext *pb,
     return 0;
 }
 
-int ff_mov_cenc_avc_parse_nal_units(MOVMuxCencContext* ctx, AVIOContext *pb,
-                                 const uint8_t *buf_in, int size)
+// TODO refactor with ff_mov_cenc_h2645_write_nal_units
+int ff_mov_cenc_avc_parse_nal_units(AVFormatContext *s, MOVMuxCencContext* ctx,
+                                    AVIOContext *pb, AVPacket *pkt)
 {
-    const uint8_t *p = buf_in;
-    const uint8_t *end = p + size;
+    int encsize, nalsize, naltype, ret, slice_header_len;
+    int clear_bytes = 0;
+    int encrypted_bytes = 0;
+    int nal_index = 0;
+    int size = 0;
+    const uint8_t *start = pkt->data;
+    const uint8_t *end = start + pkt->size;
     const uint8_t *nal_start, *nal_end;
-    int ret;
+    uint8_t *parsed_buf_out;
+    int parsed_buf_out_size;
+    int header_bits;
+    H2645NAL *nals;
+    int nals_valid;
 
     ret = mov_cenc_start_packet(ctx);
     if (ret) {
         return ret;
     }
 
-    size = 0;
-    nal_start = ff_nal_find_startcode(p, end);
+    nals_valid = ctx->parser &&
+        av_parser_parse2(ctx->parser, ctx->parser_avctx, &parsed_buf_out,
+            &parsed_buf_out_size, pkt->data, pkt->size, pkt->pts, pkt->dts, pkt->pos) >= 0;
+    nals = nals_valid ? (H2645NAL*) avpriv_h264_extract_nals(ctx->parser) : NULL;
+
+    nal_start = ff_nal_find_startcode(start, end);
     for (;;) {
         while (nal_start < end && !*(nal_start++));
-        if (nal_start == end)
+        if (nal_start == end) {
+            if (ctx->subsample_count == 0) {
+                /* must write at least one subsample before exiting */
+                auxiliary_info_add_subsample(ctx, clear_bytes, encrypted_bytes);
+            }
             break;
+        }
 
         nal_end = ff_nal_find_startcode(nal_start, end);
+        nalsize = nal_end - nal_start;
+        avio_wb32(pb, nalsize);
+        clear_bytes += 4;
 
-        avio_wb32(pb, nal_end - nal_start);
-        avio_w8(pb, *nal_start);
-        mov_cenc_write_encrypted(ctx, pb, nal_start + 1, nal_end - nal_start - 1);
+        naltype = *nal_start & 0x1f;
+        header_bits = (nals && nal_index < 32 /* MAX_SLICES */) ? nals[nal_index].slice_header_len_bits : 0;
+        slice_header_len = (header_bits + 7) / 8;
+        if ((naltype == 1 || naltype == 5) &&
+             nalsize >= slice_header_len + AES_BLOCK_SIZE)
+        {
+            avio_write(pb, nal_start, slice_header_len);
+            clear_bytes += slice_header_len;
 
-        auxiliary_info_add_subsample(ctx, 5, nal_end - nal_start - 1);
+            encsize = nalsize - slice_header_len;
+            mov_cenc_write_encrypted(ctx, pb, nal_start + slice_header_len, encsize);
+            encrypted_bytes += encsize;
+
+            auxiliary_info_add_subsample(ctx, clear_bytes, encrypted_bytes);
+            clear_bytes = 0;
+            encrypted_bytes = 0;
+        } else {
+            avio_write(pb, nal_start, nalsize);
+            clear_bytes += nalsize;
+        }
 
         size += 4 + nal_end - nal_start;
         nal_start = nal_end;
+        nal_index++;
     }
 
     ret = mov_cenc_end_packet(ctx);
@@ -234,45 +324,92 @@ int ff_mov_cenc_avc_parse_nal_units(MOVMuxCencContext* ctx, AVIOContext *pb,
     return size;
 }
 
-int ff_mov_cenc_avc_write_nal_units(AVFormatContext *s, MOVMuxCencContext* ctx,
-    int nal_length_size, AVIOContext *pb, const uint8_t *buf_in, int size)
+// TODO combine with ff_mov_cenc_avc_parse_nal_units
+int ff_mov_cenc_h2645_write_nal_units(AVFormatContext *s, MOVMuxCencContext *ctx,
+                                      AVIOContext *pb, AVPacket *pkt)
 {
-    int nalsize;
-    int ret;
-    int j;
+    int encsize, j, nalsize, naltype, ret, slice_header_len, header_bits;
+    int clear_bytes = 0;
+    int encrypted_bytes = 0;
+    int nal_index = 0;
+    int size = 0;
+    const uint8_t *buf_in = pkt->data;
+    int remaining = pkt->size;
+    uint8_t *parsed_buf_out;
+    int parsed_buf_out_size;
+    H2645NAL* nals;
+    int nals_valid;
+    AVCodecParameters *par = s->streams[pkt->stream_index]->codecpar;
+    int nal_length_size = (par->extradata[4] & 0x3) + 1;
+
+    if (par->codec_id == AV_CODEC_ID_HEVC) {
+        nal_length_size = (par->extradata[21] & 0x3) + 1;
+    }
 
     ret = mov_cenc_start_packet(ctx);
     if (ret) {
         return ret;
     }
 
-    while (size > 0) {
+    nals_valid = ctx->parser &&
+        av_parser_parse2(ctx->parser, ctx->parser_avctx, &parsed_buf_out,
+            &parsed_buf_out_size, pkt->data, pkt->size, pkt->pts, pkt->dts, pkt->pos) >= 0;
+    nals = nals_valid ? (H2645NAL*)avpriv_h264_extract_nals(ctx->parser) : NULL;
+
+    // TODO maybe use parsed info above to not parse again below
+    while (remaining > 0) {
         /* parse the nal size */
-        if (size < nal_length_size + 1) {
-            av_log(s, AV_LOG_ERROR, "CENC-AVC: remaining size %d smaller than nal length+type %d\n",
-                size, nal_length_size + 1);
+        if (remaining < nal_length_size) {
+            av_log(s, AV_LOG_ERROR, "CENC-AVC: remaining size %d smaller than nal length header %d\n", remaining, nal_length_size);
             return -1;
         }
 
-        avio_write(pb, buf_in, nal_length_size + 1);
-
+        avio_write(pb, buf_in, nal_length_size);
         nalsize = 0;
         for (j = 0; j < nal_length_size; j++) {
             nalsize = (nalsize << 8) | *buf_in++;
         }
-        size -= nal_length_size;
+        clear_bytes += nal_length_size;
+        remaining -= nal_length_size;
 
-        /* encrypt the nal body */
-        if (nalsize <= 0 || nalsize > size) {
-            av_log(s, AV_LOG_ERROR, "CENC-AVC: nal size %d remaining %d\n", nalsize, size);
+        if (nalsize <= 0 || nalsize > remaining) {
+            av_log(s, AV_LOG_ERROR, "CENC-AVC: nal size %d, remaining %d\n", nalsize, remaining);
             return -1;
         }
 
-        mov_cenc_write_encrypted(ctx, pb, buf_in + 1, nalsize - 1);
-        buf_in += nalsize;
-        size -= nalsize;
+        /**
+         * Only encrypt slice data 1 H264_NAL_SLICE and 5 H264_NAL_IDR_SLICE.
+         * Leave other nal types and VCL (video) slice headers clear, per Apple
+         * MPEG-2 HLS encryption and CENC specs.
+         */
+        naltype = *buf_in & 0x1f;
+        header_bits = (nals && nal_index < 32 /* MAX_SLICES */) ? nals[nal_index].slice_header_len_bits : 0;
+        slice_header_len = (header_bits + 7) / 8;
+        if ((naltype == 1 || naltype == 5) &&
+             nalsize >= slice_header_len + AES_BLOCK_SIZE)
+        {
+            avio_write(pb, buf_in, slice_header_len);
+            clear_bytes += slice_header_len;
 
-        auxiliary_info_add_subsample(ctx, nal_length_size + 1, nalsize - 1);
+            encsize = nalsize - slice_header_len;
+            mov_cenc_write_encrypted(ctx, pb, buf_in + slice_header_len, encsize);
+            encrypted_bytes += encsize;
+
+            auxiliary_info_add_subsample(ctx, clear_bytes, encrypted_bytes);
+            clear_bytes = 0;
+            encrypted_bytes = 0;
+        } else {
+            avio_write(pb, buf_in, nalsize);
+            clear_bytes += nalsize;
+            if (remaining - nalsize <= 0 && ctx->subsample_count == 0) {
+                /* must write at least one subsample before exiting */
+                auxiliary_info_add_subsample(ctx, clear_bytes, encrypted_bytes);
+            }
+        }
+        remaining -= nalsize;
+        size += nal_length_size + nalsize;
+        buf_in += nalsize;
+        nal_index++;
     }
 
     ret = mov_cenc_end_packet(ctx);
@@ -280,7 +417,7 @@ int ff_mov_cenc_avc_write_nal_units(AVFormatContext *s, MOVMuxCencContext* ctx,
         return ret;
     }
 
-    return 0;
+    return size;
 }
 
 static int write_tiles(AVFormatContext *s, MOVMuxCencContext *ctx, AVIOContext *pb, AV1_OBU_Type type,
@@ -491,46 +628,63 @@ static int64_t update_size(AVIOContext *pb, int64_t pos)
     return curpos - pos;
 }
 
-static int mov_cenc_write_senc_tag(MOVMuxCencContext* ctx, AVIOContext *pb,
-                                   int64_t* auxiliary_info_offset)
+int ff_mov_cenc_write_senc_tag(MOVMuxCencContext* ctx, AVIOContext *pb, int64_t moof_offset)
 {
-    int64_t pos = avio_tell(pb);
+    int64_t pos;
 
+    if (ctx->auxiliary_info_entries == 0) {
+        return 0;
+    }
+
+    pos = avio_tell(pb);
     avio_wb32(pb, 0); /* size */
     ffio_wfourcc(pb, "senc");
     avio_wb32(pb, ctx->use_subsamples ? 0x02 : 0); /* version & flags */
     avio_wb32(pb, ctx->auxiliary_info_entries); /* entry count */
-    *auxiliary_info_offset = avio_tell(pb);
+    ctx->auxiliary_info_offset = avio_tell(pb) - moof_offset;
     avio_write(pb, ctx->auxiliary_info, ctx->auxiliary_info_size);
     return update_size(pb, pos);
 }
 
-static int mov_cenc_write_saio_tag(AVIOContext *pb, int64_t auxiliary_info_offset)
+static int mov_cenc_write_saio_tag(MOVMuxCencContext* ctx, AVIOContext *pb)
 {
-    int64_t pos = avio_tell(pb);
+    int64_t pos;
     uint8_t version;
 
+    if (ctx->auxiliary_info_entries == 0) {
+        return 0;
+    }
+
+    pos = avio_tell(pb);
     avio_wb32(pb, 0); /* size */
     ffio_wfourcc(pb, "saio");
-    version = auxiliary_info_offset > 0xffffffff ? 1 : 0;
+    version = ctx->auxiliary_info_offset > 0xffffffff ? 1 : 0;
     avio_w8(pb, version);
     avio_wb24(pb, 0); /* flags */
     avio_wb32(pb, 1); /* entry count */
     if (version) {
-        avio_wb64(pb, auxiliary_info_offset);
+        avio_wb64(pb, ctx->auxiliary_info_offset);
     } else {
-        avio_wb32(pb, auxiliary_info_offset);
+        avio_wb32(pb, ctx->auxiliary_info_offset);
     }
     return update_size(pb, pos);
 }
 
 static int mov_cenc_write_saiz_tag(MOVMuxCencContext* ctx, AVIOContext *pb)
 {
-    int64_t pos = avio_tell(pb);
+    int64_t pos;
+    /* constant iv for cbcs, so sample iv is always zero */
+    uint8_t iv_size = ctx->encryption_scheme == MOV_ENC_CENC_AES_CTR ? AES_CTR_IV_SIZE : 0;
+
+    if (ctx->auxiliary_info_entries == 0) {
+        return 0;
+    }
+
+    pos = avio_tell(pb);
     avio_wb32(pb, 0); /* size */
     ffio_wfourcc(pb, "saiz");
     avio_wb32(pb, 0); /* version & flags */
-    avio_w8(pb, ctx->use_subsamples ? 0 : AES_CTR_IV_SIZE);    /* default size*/
+    avio_w8(pb, ctx->use_subsamples ? 0 : iv_size); /* default size */
     avio_wb32(pb, ctx->auxiliary_info_entries); /* entry count */
     if (ctx->use_subsamples) {
         avio_write(pb, ctx->auxiliary_info_sizes, ctx->auxiliary_info_entries);
@@ -541,25 +695,38 @@ static int mov_cenc_write_saiz_tag(MOVMuxCencContext* ctx, AVIOContext *pb)
 void ff_mov_cenc_write_stbl_atoms(MOVMuxCencContext* ctx, AVIOContext *pb,
                                   int64_t moof_offset)
 {
-    int64_t auxiliary_info_offset;
-
-    mov_cenc_write_senc_tag(ctx, pb, &auxiliary_info_offset);
-    mov_cenc_write_saio_tag(pb, auxiliary_info_offset - moof_offset);
+    mov_cenc_write_saio_tag(ctx, pb);
     mov_cenc_write_saiz_tag(ctx, pb);
 }
 
-static int mov_cenc_write_schi_tag(AVIOContext *pb, uint8_t* kid)
+static int mov_cenc_write_schi_tag(MOVTrack* track, AVIOContext *pb, uint8_t* kid)
 {
+    size_t iv_size;
     int64_t pos = avio_tell(pb);
     avio_wb32(pb, 0);     /* size */
     ffio_wfourcc(pb, "schi");
 
-    avio_wb32(pb, 32);    /* size */
-    ffio_wfourcc(pb, "tenc");
-    avio_wb32(pb, 0);     /* version & flags */
-    avio_wb24(pb, 1);     /* is encrypted */
-    avio_w8(pb, AES_CTR_IV_SIZE); /* iv size */
-    avio_write(pb, kid, CENC_KID_SIZE);
+    if (track->cenc.encryption_scheme == MOV_ENC_CENC_AES_CTR) {
+        avio_wb32(pb, 16 + CENC_KID_SIZE);  /* size */
+        ffio_wfourcc(pb, "tenc");
+        avio_wb32(pb, 0);                   /* version & flags */
+        avio_wb24(pb, 1);                   /* default_isProtected */
+        avio_w8(pb, AES_CTR_IV_SIZE);       /* default_Per_Sample_IV_Size */
+        avio_write(pb, kid, CENC_KID_SIZE); /* default_KID */
+    } else { /* MOV_ENC_CENC_AES_CBC_PATTERN */
+        iv_size = sizeof(track->cenc.aes_cbc_iv);
+        avio_wb32(pb, 16 + CENC_KID_SIZE + 1 + iv_size);  /* size */
+        ffio_wfourcc(pb, "tenc");
+        avio_w8(pb, 1);                     /* version */
+        avio_wb24(pb, 0);                   /* flags */
+        avio_w8(pb, 0);                     /* reserved */
+        avio_w8(pb, track->cenc.use_subsamples ? 0x19 : 0); /* default_crypt_byte_block, default_skip_byte_block */
+        avio_w8(pb, 1);                     /* default_isProtected */
+        avio_w8(pb, 0);                     /* default_Per_Sample_IV_Size */
+        avio_write(pb, kid, CENC_KID_SIZE); /* default_KID */
+        avio_w8(pb, iv_size);               /* default_constant_IV_size */
+        avio_write(pb, track->cenc.aes_cbc_iv, iv_size); /* default_constant_IV */
+    }
 
     return update_size(pb, pos);
 }
@@ -567,23 +734,26 @@ static int mov_cenc_write_schi_tag(AVIOContext *pb, uint8_t* kid)
 int ff_mov_cenc_write_sinf_tag(MOVTrack* track, AVIOContext *pb, uint8_t* kid)
 {
     int64_t pos = avio_tell(pb);
-    avio_wb32(pb, 0); /* size */
+
+    /* sinf */
+    avio_wb32(pb, 0);               /* size */
     ffio_wfourcc(pb, "sinf");
 
     /* frma */
-    avio_wb32(pb, 12);    /* size */
+    avio_wb32(pb, 12);              /* size */
     ffio_wfourcc(pb, "frma");
     avio_wl32(pb, track->tag);
 
     /* schm */
-    avio_wb32(pb, 20);    /* size */
+    avio_wb32(pb, 20);              /* size */
     ffio_wfourcc(pb, "schm");
-    avio_wb32(pb, 0); /* version & flags */
-    ffio_wfourcc(pb, "cenc");    /* scheme type*/
-    avio_wb32(pb, 0x10000); /* scheme version */
+    avio_wb32(pb, 0);               /* version & flags */
+    ffio_wfourcc(pb, track->cenc.encryption_scheme == MOV_ENC_CENC_AES_CTR ?
+                 "cenc" : "cbcs");  /* scheme type*/
+    avio_wb32(pb, 0x10000);         /* scheme version */
 
     /* schi */
-    mov_cenc_write_schi_tag(pb, kid);
+    mov_cenc_write_schi_tag(track, pb, kid);
 
     return update_size(pb, pos);
 }
@@ -596,17 +766,18 @@ static const CodedBitstreamUnitType decompose_unit_types[] = {
     AV1_OBU_FRAME,
 };
 
-int ff_mov_cenc_init(MOVMuxCencContext* ctx, uint8_t* encryption_key,
-                     int use_subsamples, enum AVCodecID codec_id, int bitexact)
+static int mov_cenc_ctr_init(MOVMuxCencContext* ctx, uint8_t* key, int bitexact)
 {
     int ret;
+
+    av_assert0(ctx->aes_ctr == NULL);
 
     ctx->aes_ctr = av_aes_ctr_alloc();
     if (!ctx->aes_ctr) {
         return AVERROR(ENOMEM);
     }
 
-    ret = av_aes_ctr_init(ctx->aes_ctr, encryption_key);
+    ret = av_aes_ctr_init(ctx->aes_ctr, key);
     if (ret != 0) {
         return ret;
     }
@@ -615,7 +786,64 @@ int ff_mov_cenc_init(MOVMuxCencContext* ctx, uint8_t* encryption_key,
         av_aes_ctr_set_random_iv(ctx->aes_ctr);
     }
 
+    return 0;
+}
+
+static int mov_cenc_cbc_init(MOVMuxCencContext* ctx, uint8_t* key,
+                             uint8_t* iv, int iv_len)
+{
+    int ret;
+
+    av_assert0(ctx->aes_cbc == NULL);
+
+    ctx->aes_cbc = av_aes_alloc();
+    if (!ctx->aes_cbc) {
+        return AVERROR(ENOMEM);
+    }
+
+    ret = av_aes_init(ctx->aes_cbc, key, 128, 0);
+    if (ret != 0) {
+        return ret;
+    }
+
+    if (ctx->use_subsamples) {
+        /* hard-coded to 1 encrypted 9 clear; signaled in the tenc atom */
+        av_aes_set_pattern(ctx->aes_cbc, 1, 9);
+    }
+
+    if (iv_len == AES_BLOCK_SIZE) {
+        memcpy(ctx->aes_cbc_iv, iv, iv_len);
+    } else {
+        AV_WL32(ctx->aes_cbc_iv, av_get_random_seed());
+        AV_WL32(ctx->aes_cbc_iv + 4, av_get_random_seed());
+        AV_WL32(ctx->aes_cbc_iv + 8, av_get_random_seed());
+        AV_WL32(ctx->aes_cbc_iv + 12, av_get_random_seed());
+    }
+
+    return 0;
+}
+
+int ff_mov_cenc_init(MOVMuxCencContext* ctx, AVCodecParameters *par,
+                     MOVEncryptionScheme encryption_scheme, uint8_t* key,
+                     uint8_t* iv, int iv_len,
+                     int use_subsamples, enum AVCodecID codec_id, int bitexact)
+{
+    int ret;
+
+    ctx->encryption_scheme = encryption_scheme;
     ctx->use_subsamples = use_subsamples;
+
+    ctx->parser = av_parser_init(par->codec_id);
+    if (ctx->parser) {
+        ctx->parser_avctx = avcodec_alloc_context3(NULL);
+        if (!ctx->parser_avctx)
+            return AVERROR(ENOMEM);
+        ret = avcodec_parameters_to_context(ctx->parser_avctx, par);
+        if (ret < 0)
+            return ret;
+        // We only want to parse frame headers
+        ctx->parser->flags |= PARSER_FLAG_COMPLETE_FRAMES;
+    }
 
     if (codec_id == AV_CODEC_ID_AV1) {
         ret = ff_lavf_cbs_init(&ctx->cbc, codec_id, NULL);
@@ -626,16 +854,30 @@ int ff_mov_cenc_init(MOVMuxCencContext* ctx, uint8_t* encryption_key,
         ctx->cbc->nb_decompose_unit_types = FF_ARRAY_ELEMS(decompose_unit_types);
     }
 
+    switch (encryption_scheme) {
+    case MOV_ENC_CENC_AES_CTR:
+        return mov_cenc_ctr_init(ctx, key, bitexact);
+    case MOV_ENC_CENC_AES_CBC_PATTERN:
+        return mov_cenc_cbc_init(ctx, key, iv, iv_len);
+    default:
+        break;
+    }
     return 0;
 }
+
 
 void ff_mov_cenc_free(MOVMuxCencContext* ctx)
 {
     av_aes_ctr_free(ctx->aes_ctr);
+    if (ctx->encryption_scheme == MOV_ENC_CENC_AES_CBC_PATTERN && ctx->aes_cbc) {
+        av_freep(&ctx->aes_cbc);
+    }
     av_freep(&ctx->auxiliary_info);
     av_freep(&ctx->auxiliary_info_sizes);
 
     av_freep(&ctx->tile_group_sizes);
     ff_lavf_cbs_fragment_free(&ctx->temporal_unit);
     ff_lavf_cbs_close(&ctx->cbc);
+    av_parser_close(ctx->parser);
+    avcodec_free_context(&ctx->parser_avctx);
 }

--- a/libavformat/movenccenc.h
+++ b/libavformat/movenccenc.h
@@ -26,6 +26,7 @@
 #include "avformat.h"
 #include "avio.h"
 #include "cbs.h"
+#include "isom.h"
 
 #define CENC_KID_SIZE (16)
 
@@ -38,18 +39,22 @@ struct MOVMuxCencAV1TGInfo {
 };
 
 typedef struct {
+    MOVEncryptionScheme encryption_scheme;
+    struct AVAES* aes_cbc;
+    uint8_t aes_cbc_iv[16]; /* AES_BLOCK_SIZE */
     struct AVAESCTR* aes_ctr;
     uint8_t* auxiliary_info;
     size_t auxiliary_info_size;
     size_t auxiliary_info_alloc_size;
     uint32_t auxiliary_info_entries;
+    uint8_t* auxiliary_info_sizes;
+    size_t  auxiliary_info_sizes_alloc_size;
+    int64_t auxiliary_info_offset;
 
     /* subsample support */
     int use_subsamples;
     uint16_t subsample_count;
-    size_t auxiliary_info_subsample_start;
-    uint8_t* auxiliary_info_sizes;
-    size_t  auxiliary_info_sizes_alloc_size;
+    size_t auxiliary_info_subsample_start; /* location to write subsample_count */
 
     /* AV1 */
     struct MOVMuxCencAV1TGInfo *tile_group_sizes;
@@ -58,6 +63,9 @@ typedef struct {
     /* CBS */
     CodedBitstreamContext *cbc;
     CodedBitstreamFragment temporal_unit;
+
+    struct AVCodecParserContext *parser;
+    struct AVCodecContext *parser_avctx;
 } MOVMuxCencContext;
 
 /**
@@ -65,8 +73,10 @@ typedef struct {
  * @param key encryption key, must have a length of AES_CTR_KEY_SIZE
  * @param use_subsamples when enabled parts of a packet can be encrypted, otherwise the whole packet is encrypted
  */
-int ff_mov_cenc_init(MOVMuxCencContext* ctx, uint8_t* encryption_key, int use_subsamples,
-                     enum AVCodecID codec_id, int bitexact);
+int ff_mov_cenc_init(MOVMuxCencContext* ctx, AVCodecParameters *par,
+                     MOVEncryptionScheme encryption_scheme, uint8_t* encryption_key,
+                     uint8_t* encryption_iv, int encryption_iv_len,
+                     int use_subsamples, enum AVCodecID codec_id, int bitexact);
 
 /**
  * Free a CENC context
@@ -79,20 +89,34 @@ void ff_mov_cenc_free(MOVMuxCencContext* ctx);
 int ff_mov_cenc_write_packet(MOVMuxCencContext* ctx, AVIOContext *pb, const uint8_t *buf_in, int size);
 
 /**
- * Parse AVC NAL units from annex B format, the nal size and type are written in the clear while the body is encrypted
+ * Parse AVC NAL units from Annex B format. The NAL size and header, and VCL
+ * slice headers, are written in the clear while the body is encrypted.
+ *
+ * Returns bytes written, or < 0 on error
  */
-int ff_mov_cenc_avc_parse_nal_units(MOVMuxCencContext* ctx, AVIOContext *pb, const uint8_t *buf_in, int size);
+int ff_mov_cenc_avc_parse_nal_units(AVFormatContext *s, MOVMuxCencContext* ctx,
+                                    AVIOContext *pb, AVPacket *pkt);
 
 /**
- * Write AVC NAL units that are in MP4 format, the nal size and type are written in the clear while the body is encrypted
+ * Write AVC NAL units that are in MP4 format. The NAL size and header, and VCL
+ * slice headers, are written in the clear while the body is encrypted.
+ *
+ * Returns bytes written, or < 0 on error
  */
-int ff_mov_cenc_avc_write_nal_units(AVFormatContext *s, MOVMuxCencContext* ctx, int nal_length_size,
-    AVIOContext *pb, const uint8_t *buf_in, int size);
+int ff_mov_cenc_h2645_write_nal_units(AVFormatContext *s, MOVMuxCencContext *ctx,
+                                      AVIOContext *pb, AVPacket *pkt);
+
+/**
+ * Write the cenc atoms that should reside inside senc
+ * The senc can reside in either traf or trak
+ */
+int ff_mov_cenc_write_senc_tag(MOVMuxCencContext* ctx, AVIOContext *pb, int64_t moof_offset);
 
 int ff_mov_cenc_av1_write_obus(AVFormatContext *s, MOVMuxCencContext* ctx,
                                AVIOContext *pb, const AVPacket *pkt);
 /**
  * Write the cenc atoms that should reside inside stbl
+ * Write the senc first to get the auxiliary_info_offset for saio
  */
 void ff_mov_cenc_write_stbl_atoms(MOVMuxCencContext* ctx, AVIOContext *pb, int64_t moof_offset);
 
@@ -100,5 +124,11 @@ void ff_mov_cenc_write_stbl_atoms(MOVMuxCencContext* ctx, AVIOContext *pb, int64
  * Write the sinf atom, contained inside stsd
  */
 int ff_mov_cenc_write_sinf_tag(struct MOVTrack* track, AVIOContext *pb, uint8_t* kid);
+
+/**
+ * Reset aux info for next moof
+ */
+void ff_mov_cenc_auxiliary_info_reset(MOVMuxCencContext* ctx);
+
 
 #endif /* AVFORMAT_MOVENCCENC_H */

--- a/libavutil/aes.c
+++ b/libavutil/aes.c
@@ -139,16 +139,26 @@ static inline void aes_crypt(AVAES *a, int s, const uint8_t *sbox,
 static void aes_encrypt(AVAES *a, uint8_t *dst, const uint8_t *src,
                         int count, uint8_t *iv, int rounds)
 {
-    while (count--) {
-        addkey_s(&a->state[1], src, &a->round_key[rounds]);
-        if (iv)
-            addkey_s(&a->state[1], iv, &a->state[1]);
-        aes_crypt(a, 2, sbox, enc_multbl);
-        addkey_d(dst, &a->state[0], &a->round_key[0]);
-        if (iv)
-            memcpy(iv, dst, 16);
+    int i = 0;
+    int pattern_block_length = a->crypt_byte_block + a->skip_byte_block;
+
+    while (i < count) {
+        if (pattern_block_length == 0 ||
+            i % pattern_block_length < a->crypt_byte_block)
+        {
+            addkey_s(&a->state[1], src, &a->round_key[rounds]);
+            if (iv)
+                addkey_s(&a->state[1], iv, &a->state[1]);
+            aes_crypt(a, 2, sbox, enc_multbl);
+            addkey_d(dst, &a->state[0], &a->round_key[0]);
+            if (iv)
+                memcpy(iv, dst, 16);
+        } else {
+            memcpy(dst, src, 16); // skip encryption
+        }
         src += 16;
         dst += 16;
+        i++;
     }
 }
 
@@ -280,4 +290,9 @@ int av_aes_init(AVAES *a, const uint8_t *key, int key_bits, int decrypt)
     }
 
     return 0;
+}
+
+void av_aes_set_pattern(struct AVAES *a, int crypt_byte_block, int skip_byte_block) {
+    a->crypt_byte_block = crypt_byte_block;
+    a->skip_byte_block = skip_byte_block;
 }

--- a/libavutil/aes.h
+++ b/libavutil/aes.h
@@ -51,6 +51,11 @@ struct AVAES *av_aes_alloc(void);
 int av_aes_init(struct AVAES *a, const uint8_t *key, int key_bits, int decrypt);
 
 /**
+ * Enable pattern encryption
+ */
+void av_aes_set_pattern(struct AVAES *a, int crypt_byte_block, int skip_byte_block);
+
+/**
  * Encrypt or decrypt a buffer using a previously initialized context.
  *
  * @param a The AVAES context

--- a/libavutil/aes_internal.h
+++ b/libavutil/aes_internal.h
@@ -37,6 +37,8 @@ typedef struct AVAES {
     DECLARE_ALIGNED(16, av_aes_block, round_key)[15];
     DECLARE_ALIGNED(16, av_aes_block, state)[2];
     int rounds;
+    int crypt_byte_block;
+    int skip_byte_block;
     void (*crypt)(struct AVAES *a, uint8_t *dst, const uint8_t *src, int count, uint8_t *iv, int rounds);
 } AVAES;
 


### PR DESCRIPTION
- Add AES-CBC pattern encryption (cenc-aes-cbc-pattern) alongside existing AES-CTR
- Implement subsample encryption with clear slice headers for H.264/H.265
- Extend H.264 parser to fully parse slice headers and expose NAL data for CENC
- Add av_aes_set_pattern() for CENC CBCS 1:9 encrypt/skip pattern
- Write senc box separately from saio/saiz per ISO BMFF spec
- Support custom encryption IVs
- Add AES-128 segment-level encryption to DASH muxer
- Add CENC pass-through options in DASH muxer forwarded to MOV muxer