### PR TITLE
ELUVIO - segment cutting by PTS and avpipe integration for dash/segment muxers

### DIFF
--- a/libavformat/avformat.h
+++ b/libavformat/avformat.h
@@ -1884,6 +1884,18 @@ typedef struct AVFormatContext {
      * @see skip_estimate_duration_from_pts
      */
     int64_t duration_probesize;
+
+    /* Special for avpipe, holds out_handler */
+    void *avpipe_opaque;
+    
+    /*
+     * Keep track of min and max of frame duration and calculate the following:
+     * frame_duration_variation = (max_frame_duration - min_frame_duration) * 2;
+     * frame_duration_variation will be used to cut ABR dash/hls segments.
+     */
+    int64_t prev_pts;
+    int64_t min_frame_duration;
+    int64_t max_frame_duration;
 } AVFormatContext;
 
 /**
@@ -2826,16 +2838,20 @@ void av_dump_format(AVFormatContext *ic,
  *
  * Also handles the '%0nd' format where 'n' is the total number
  * of digits and '%%'.
+ * 
+ * ELUVIO MERGE NOTE: This was modified in order to adjust the number from int to int64_t. When
+ * upgrading to ffmpeg 7.2, this change will become unnecessary, and the commit can be discarded
+ * when merging/rebasing.
  *
  * @param buf destination buffer
  * @param buf_size destination buffer size
  * @param path numbered sequence string
- * @param number frame number
+ * @param number frame number or PTS
  * @param flags AV_FRAME_FILENAME_FLAGS_*
  * @return 0 if OK, -1 on format error
  */
 int av_get_frame_filename2(char *buf, int buf_size,
-                          const char *path, int number, int flags);
+                          const char *path, int64_t number, int flags);
 
 int av_get_frame_filename(char *buf, int buf_size,
                           const char *path, int number);

--- a/libavformat/dashenc.c
+++ b/libavformat/dashenc.c
@@ -223,6 +223,11 @@ typedef struct DASHContext {
     AVRational min_playback_rate;
     AVRational max_playback_rate;
     int64_t update_period;
+    int start_segment;
+
+    int64_t seg_duration_ts;
+    int64_t start_fragment_index;
+    int64_t frame_duration_ts;
 
     // Pass-through options to movenc -PTT
     char *encryption_scheme_str;
@@ -604,8 +609,9 @@ static void write_hls_media_playlist(OutputStream *os, AVFormatContext *s,
     AVDictionary *http_opts = NULL;
     int target_duration = 0;
     int ret = 0;
-    const char *proto = avio_find_protocol_name(c->dirname);
-    int use_rename = proto && !strcmp(proto, "file");
+    //const char *proto = avio_find_protocol_name(c->dirname);
+    //int use_rename = proto && !strcmp(proto, "file");
+    int use_rename = 0;
     int i, start_index, start_number;
     double prog_date_time = 0;
 
@@ -933,7 +939,7 @@ static int write_adaptation_set(AVFormatContext *s, AVIOContext *out, int as_ind
 
         if (os->bit_rate > 0)
             snprintf(bandwidth_str, sizeof(bandwidth_str), " bandwidth=\"%d\"", os->bit_rate);
-        else if (final) {
+        else if (final && (c->total_duration > 0)) {
             int average_bit_rate = os->pos * 8 * AV_TIME_BASE / c->total_duration;
             snprintf(bandwidth_str, sizeof(bandwidth_str), " bandwidth=\"%d\"", average_bit_rate);
         } else if (os->first_segment_bit_rate > 0)
@@ -1245,6 +1251,8 @@ static int write_manifest(AVFormatContext *s, int final)
 
     if (!use_rename && !warned_non_file++)
         av_log(s, AV_LOG_ERROR, "Cannot use rename on non file protocol, this may lead to races and temporary partial files\n");
+
+    use_rename = 0; // PENDING(SSS) need protocol 'buf'
 
     snprintf(temp_filename, sizeof(temp_filename), use_rename ? "%s.tmp" : "%s", s->url);
     set_http_options(&opts, c);
@@ -1567,6 +1575,10 @@ static int dash_init(AVFormatContext *s)
     if (c->single_file)
         c->use_template = 0;
 
+    s->min_frame_duration = INT64_MAX;
+    s->max_frame_duration = INT64_MIN;
+    s->prev_pts = AV_NOPTS_VALUE;
+
     if (!c->profile) {
         av_log(s, AV_LOG_ERROR, "At least one profile must be enabled.\n");
         return AVERROR(EINVAL);
@@ -1676,6 +1688,7 @@ static int dash_init(AVFormatContext *s)
         AVStream *st;
         AVDictionary *opts = NULL;
         char filename[1024];
+        AVRational time_base;
 
         os->bit_rate = s->streams[i]->codecpar->bit_rate;
         if (!os->bit_rate) {
@@ -1818,23 +1831,32 @@ static int dash_init(AVFormatContext *s)
 
         if (os->segment_type == SEGMENT_TYPE_MP4) {
             if (c->streaming)
+                // frag_every_frame : Allows lower latency streaming
                 // skip_sidx : Reduce bitrate overhead
                 // skip_trailer : Avoids growing memory usage with time
-                av_dict_set(&opts, "movflags", "+dash+delay_moov+skip_sidx+skip_trailer", AV_DICT_APPEND);
+                av_dict_set(&opts, "movflags", "frag_every_frame+dash+delay_moov+skip_sidx+skip_trailer", 0);
             else {
-                if (c->global_sidx)
-                    av_dict_set(&opts, "movflags", "+dash+delay_moov+global_sidx+skip_trailer", AV_DICT_APPEND);
-                else
-                    av_dict_set(&opts, "movflags", "+dash+delay_moov+skip_trailer", AV_DICT_APPEND);
+                if (c->global_sidx) {
+                    if (c->start_segment > 1) {
+                        av_dict_set(&opts, "movflags", "frag_every_frame+dash+delay_moov+frag_discont+skip_trailer", 0);
+                    } else {
+                        av_dict_set(&opts, "movflags", "frag_every_frame+dash+delay_moov+skip_trailer", 0);
+                    }
+                } else {
+                    if (c->start_segment > 1) {
+                        av_dict_set(&opts, "movflags", "frag_every_frame+dash+delay_moov+frag_discont", 0);
+                    } else {
+                        av_dict_set(&opts, "movflags", "frag_every_frame+dash+delay_moov", 0);
+                    }
+                }
             }
-            if (os->frag_type == FRAG_TYPE_EVERY_FRAME)
-                av_dict_set(&opts, "movflags", "+frag_every_frame", AV_DICT_APPEND);
-            else
-                av_dict_set(&opts, "movflags", "+frag_custom", AV_DICT_APPEND);
-            if (os->frag_type == FRAG_TYPE_DURATION)
-                av_dict_set_int(&opts, "frag_duration", os->frag_duration, 0);
-            if (c->write_prft)
-                av_dict_set(&opts, "write_prft", "wallclock", 0);
+
+            if (c->start_fragment_index > 1) {
+                char start_fragment_index_str[128];
+                (void)sprintf(start_fragment_index_str, "%" PRId64, c->start_fragment_index);
+                av_dict_set(&opts, "fragment_index", start_fragment_index_str, 0);
+                av_log(s, AV_LOG_INFO, "Fragment index=%s", start_fragment_index_str);
+            }
 
             if (c->encryption_scheme_str != NULL) {
                 av_dict_set(&opts, "encryption_scheme", c->encryption_scheme_str, 0);
@@ -1848,6 +1870,14 @@ static int dash_init(AVFormatContext *s)
             if (c->encryption_iv != NULL) {
                 av_dict_set(&opts, "encryption_iv", c->encryption_iv, 0);
             }
+            if (os->frag_type == FRAG_TYPE_EVERY_FRAME)
+                av_dict_set(&opts, "movflags", "+frag_every_frame", AV_DICT_APPEND);
+            else
+                av_dict_set(&opts, "movflags", "+frag_custom", AV_DICT_APPEND);
+            if (os->frag_type == FRAG_TYPE_DURATION)
+                av_dict_set_int(&opts, "frag_duration", os->frag_duration, 0);
+            if (c->write_prft)
+                av_dict_set(&opts, "write_prft", "wallclock", 0);
         } else {
             av_dict_set_int(&opts, "cluster_time_limit", c->seg_duration / 1000, 0);
             av_dict_set_int(&opts, "cluster_size_limit", 5 * 1024 * 1024, 0); // set a large cluster size limit
@@ -1855,7 +1885,18 @@ static int dash_init(AVFormatContext *s)
             av_dict_set_int(&opts, "dash_track_number", i + 1, 0);
             av_dict_set_int(&opts, "live", 1, 0);
         }
+        time_base = st->time_base;
+        /* avformat_init_output() might change stream time_base if time_base < 10000 */
         ret = avformat_init_output(ctx, &opts);
+        /*
+         * Basically the problem is when time_base < 10000, then ffmpeg doubles the timebase in a loop (in movenc.c)
+         * until it becomes bigger than 10000 (i.e 600 -> 19200).
+         * This change in the time_base causes a divide by zero in dash_flush() function.
+         * To avoid this situation, it is needed to rescale seg_duration_ts too.
+         */
+        if (time_base.den != st->time_base.den) {
+            c->seg_duration_ts *= st->time_base.den/(time_base.den*st->time_base.num);
+        }
         av_dict_free(&opts);
         if (ret < 0)
             return ret;
@@ -1904,12 +1945,22 @@ static int dash_init(AVFormatContext *s)
             c->has_video = 1;
         }
 
+        /* Calculate the seg_duration in time_base units */
+#if 0
+        c->seg_duration_ts =
+            (c->seg_duration * s->streams[i]->time_base.den) /
+            (1000000 * s->streams[i]->time_base.num);
+        av_log(s, AV_LOG_DEBUG, "HAPPY seg_duration_ts=%lld mod=%lld\n", c->seg_duration_ts,
+            c->seg_duration * s->streams[i]->time_base.den % (1000000 * s->streams[i]->time_base.num));
+#endif
+        av_log(s, AV_LOG_DEBUG, "seg_duration_ts=%"PRId64"\n", c->seg_duration_ts);
+
         set_codec_str(s, st->codecpar, &st->avg_frame_rate, os->codec_str,
                       sizeof(os->codec_str));
         os->first_pts = AV_NOPTS_VALUE;
         os->max_pts = AV_NOPTS_VALUE;
         os->last_dts = AV_NOPTS_VALUE;
-        os->segment_index = 1;
+        os->segment_index = c->start_segment;
 
         if (s->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
             c->nr_of_streams_to_flush++;
@@ -2113,6 +2164,8 @@ static int dash_flush(AVFormatContext *s, int final, int stream)
     const char *proto = avio_find_protocol_name(s->url);
     int use_rename = proto && !strcmp(proto, "file");
 
+    use_rename = 0;
+
     int cur_flush_segment_index = 0, next_exp_index = -1;
     if (stream >= 0) {
         cur_flush_segment_index = c->streams[stream].segment_index;
@@ -2176,6 +2229,20 @@ static int dash_flush(AVFormatContext *s, int final, int stream)
 
         duration = av_rescale_q(os->max_pts - os->start_pts, st->time_base, AV_TIME_BASE_Q);
         os->last_duration = FFMAX(os->last_duration, duration);
+
+        if (!os->muxer_overhead) {
+            if (av_rescale_q(os->max_pts - os->start_pts, st->time_base, AV_TIME_BASE_Q) != 0)
+                os->muxer_overhead = ((int64_t) (range_length - os->total_pkt_size) *
+                                   8 * AV_TIME_BASE) /
+                                  av_rescale_q(os->max_pts - os->start_pts,
+                                               st->time_base, AV_TIME_BASE_Q);
+            else
+                /* This (else) should not happen anymore after rescaling seg_duration_ts.
+                 * But just to be on the safe side I will keep this.
+                 */
+                os->muxer_overhead = ((int64_t) (range_length - os->total_pkt_size) *
+                                  8 * AV_TIME_BASE) * st->time_base.num / st->time_base.den;
+        }
 
         if (!os->muxer_overhead && os->max_pts > os->start_pts)
             os->muxer_overhead = ((int64_t) (range_length - os->total_pkt_size) *
@@ -2346,6 +2413,33 @@ static int dash_write_packet(AVFormatContext *s, AVPacket *pkt)
         seg_end_duration = os->seg_duration;
     }
 
+    if (s->prev_pts != AV_NOPTS_VALUE) {
+        int64_t delta = pkt->pts - s->prev_pts;
+        delta = delta > 0 ? delta : (-1)*delta;
+        if (delta < s->min_frame_duration)
+            s->min_frame_duration = delta;
+        if (delta > s->max_frame_duration)
+            s->max_frame_duration = delta;
+    }
+
+    int64_t frame_duration_variation = 0;
+
+    if (s->prev_pts != AV_NOPTS_VALUE) {
+        frame_duration_variation = (s->max_frame_duration - s->min_frame_duration) * 2;
+        if (frame_duration_variation > pkt->duration/2 + 1)
+            frame_duration_variation = pkt->duration/2 + 1;
+    }
+
+    /*
+     * This is just for backward compatibility and not break anything.
+     * (we used to set frame_duration_variation = 1)
+     */
+    if (frame_duration_variation == 0)
+        frame_duration_variation = 1;
+
+    s->prev_pts = pkt->pts;
+
+
     if (os->parser &&
         (os->frag_type == FRAG_TYPE_PFRAMES ||
          as->trick_idx >= 0)) {
@@ -2359,9 +2453,29 @@ static int dash_write_packet(AVFormatContext *s, AVPacket *pkt)
         os->coding_dependency |= os->parser->pict_type != AV_PICTURE_TYPE_I;
     }
 
+#if 0
+    av_log(s, AV_LOG_INFO, "dash_write_packet is_key=%d pts=%"PRId64" duration=%"PRId64" start_pts=%"PRId64
+        " max_pts=%"PRId64" elapsed_duration=%"PRId64" seg_duration_ts=%"PRId64" frame_duration_variation=%"PRId64
+        " min_frame_duration=%"PRId64" max_frame_duration=%"PRId64,
+        pkt->flags & AV_PKT_FLAG_KEY, pkt->pts, pkt->duration, os->start_pts, os->max_pts,
+        elapsed_duration, c->seg_duration_ts, frame_duration_variation,
+        s->min_frame_duration, s->max_frame_duration);
+#endif
+    /*
+     * For the rare case frame duration is not a timebase integer (for example 1501.5)
+     * or if frame duration is not constant we need to accommodate for the variation.
+     * When frame duration is fractional, the variation is always 1
+     * In another case, like PBS live stream, the packet duration is variable (for example 2970, or 3060).
+     * In this case, the cutting might not happen in exact PTS that is expected. Therefore, cut within a window
+     * or interval around expected PTS.
+     */
+
     if (pkt->flags & AV_PKT_FLAG_KEY && os->packets_written &&
-        av_compare_ts(elapsed_duration, st->time_base,
-                      seg_end_duration, AV_TIME_BASE_Q) >= 0) {
+        elapsed_duration + frame_duration_variation >= c->seg_duration_ts)
+        /* av_compare_ts(elapsed_duration, st->time_base,
+                      seg_end_duration, AV_TIME_BASE_Q) >= 0)
+        */
+    {
         if (!c->has_video || st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
             c->last_duration = av_rescale_q(pkt->pts - os->start_pts,
                     st->time_base,
@@ -2384,6 +2498,11 @@ static int dash_write_packet(AVFormatContext *s, AVPacket *pkt)
             format_date(os->producer_reference_time_str,
                         sizeof(os->producer_reference_time_str),
                         os->producer_reference_time.wallclock);
+
+        av_log(s, AV_LOG_DEBUG, "dash_write_packet end of segment pts=%"PRId64" duration=%"PRId64" start_pts=%"PRId64
+            " max_pts=%"PRId64" elapsed_duration=%"PRId64" seg_duration_ts=%"PRId64", frame_duration_variation=%"PRId64,
+            pkt->pts, pkt->duration, os->start_pts, os->max_pts, elapsed_duration, c->seg_duration_ts, frame_duration_variation);
+
 
         if ((ret = dash_flush(s, 0, pkt->stream_index)) < 0)
             return ret;
@@ -2444,8 +2563,10 @@ static int dash_write_packet(AVFormatContext *s, AVPacket *pkt)
     //open the output context when the first frame of a segment is ready
     if (!c->single_file && os->packets_written == 1) {
         AVDictionary *opts = NULL;
+        char stream_index[10];
         const char *proto = avio_find_protocol_name(s->url);
         int use_rename = proto && !strcmp(proto, "file");
+        use_rename = 0; // PENDING(SSS) make proto 'buf'
         if (os->segment_type == SEGMENT_TYPE_MP4)
             write_styp(os->ctx->pb);
         os->filename[0] = os->full_path[0] = os->temp_path[0] = '\0';
@@ -2457,6 +2578,8 @@ static int dash_write_packet(AVFormatContext *s, AVPacket *pkt)
         snprintf(os->temp_path, sizeof(os->temp_path),
                  use_rename ? "%s.tmp" : "%s", os->full_path);
         set_http_options(&opts, c);
+        sprintf(stream_index, "%d", pkt->stream_index);
+        av_dict_set(&opts, "stream_index", stream_index, 0);
         ret = dashenc_io_open(s, &os->out, os->temp_path, &opts);
         av_dict_free(&opts);
         if (ret < 0) {
@@ -2480,7 +2603,7 @@ static int dash_write_packet(AVFormatContext *s, AVPacket *pkt)
     }
 
     //write out the data immediately in streaming mode
-    if (c->streaming && os->segment_type == SEGMENT_TYPE_MP4) {
+    if (1 /* PENDING(SSS) figure out flag */ || (c->streaming && os->segment_type == SEGMENT_TYPE_MP4)) {
         int len = 0;
         uint8_t *buf = NULL;
         avio_flush(os->ctx->pb);
@@ -2597,7 +2720,7 @@ static const AVOption options[] = {
     { "seg_duration", "segment duration (in seconds, fractional value can be set)", OFFSET(seg_duration), AV_OPT_TYPE_DURATION, { .i64 = 5000000 }, 0, INT_MAX, E },
     { "single_file", "Store all segments in one file, accessed using byte ranges", OFFSET(single_file), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, E },
     { "single_file_name", "DASH-templated name to be used for baseURL. Implies storing all segments in one file, accessed using byte ranges", OFFSET(single_file_name), AV_OPT_TYPE_STRING, { .str = NULL }, 0, 0, E },
-    { "streaming", "Enable/Disable streaming mode of output. Each frame will be moof fragment", OFFSET(streaming), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, E },
+    { "streaming", "Enable/Disable streaming mode of output. Each frame will be moof fragment", OFFSET(streaming), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, E },    
     { "target_latency", "Set desired target latency for Low-latency dash", OFFSET(target_latency), AV_OPT_TYPE_DURATION, { .i64 = 0 }, 0, INT_MAX, E },
     { "timeout", "set timeout for socket I/O operations", OFFSET(timeout), AV_OPT_TYPE_DURATION, { .i64 = -1 }, -1, INT_MAX, .flags = E },
     { "update_period", "Set the mpd update interval", OFFSET(update_period), AV_OPT_TYPE_INT64, {.i64 = 0}, 0, INT64_MAX, E},
@@ -2606,6 +2729,10 @@ static const AVOption options[] = {
     { "utc_timing_url", "URL of the page that will return the UTC timestamp in ISO format", OFFSET(utc_timing_url), AV_OPT_TYPE_STRING, { 0 }, 0, 0, E },
     { "window_size", "number of segments kept in the manifest", OFFSET(window_size), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, INT_MAX, E },
     { "write_prft", "Write producer reference time element", OFFSET(write_prft), AV_OPT_TYPE_BOOL, {.i64 = -1}, -1, 1, E},
+    { "seg_duration_ts", "segment duration timebase", OFFSET(seg_duration_ts), AV_OPT_TYPE_INT, { .i64 = 48048 }, 0, INT_MAX, E },
+    { "start_fragment_index", "starting frame sequence for fragmented mp4", OFFSET(start_fragment_index), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, INT_MAX, E },
+    { "frame_duration_ts", "frame duration timebase", OFFSET(frame_duration_ts), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, INT_MAX, E },
+    { "start_segment", "Specify the index of the first segment (which by default is 1)", OFFSET(start_segment), AV_OPT_TYPE_INT, { .i64 = 1 }, 0, INT_MAX, E },
     { "encryption_scheme", "Configures the Common Encryption scheme, allowed values are none, cenc-aes-ctr, cenc-aes-cbc-pattern", OFFSET(encryption_scheme_str), AV_OPT_TYPE_STRING, {.str = NULL}, .flags = AV_OPT_FLAG_ENCODING_PARAM },
     { "encryption_key", "The media encryption key (hex)", OFFSET(encryption_key), AV_OPT_TYPE_STRING, {.str = NULL}, .flags = AV_OPT_FLAG_ENCODING_PARAM },
     { "encryption_kid", "The media encryption key identifier (hex)", OFFSET(encryption_kid), AV_OPT_TYPE_STRING, {.str = NULL}, .flags = AV_OPT_FLAG_ENCODING_PARAM },

--- a/libavformat/movenc.c
+++ b/libavformat/movenc.c
@@ -7921,6 +7921,15 @@ static int mov_init(AVFormatContext *s)
         return AVERROR(EINVAL);
     }
 
+    /* Call io_open call back if pb is NULL (output format is "mp4", and using mp4 muxer) */
+    if (!s->pb && s->io_open) {
+        AVDictionary *opts = NULL;
+        ret = s->io_open(s, &s->pb, s->url, AVIO_FLAG_WRITE, &opts);
+        av_dict_free(&opts);
+        if (ret < 0)
+            return ret;
+    }
+
     /* Non-seekable output is ok if using fragmentation. If ism_lookahead
      * is enabled, we don't support non-seekable output at all. */
     if (!(s->pb->seekable & AVIO_SEEKABLE_NORMAL) &&

--- a/libavformat/segment.c
+++ b/libavformat/segment.c
@@ -74,6 +74,8 @@ typedef struct SegmentContext {
     int segment_idx_wrap;  ///< number after which the index wraps
     int segment_idx_wrap_nb;  ///< number of time the index has wrapped
     int segment_count;     ///< number of segment files already written
+    int segment_start_index;
+    int segment_start_index_initialized;
     const AVOutputFormat *oformat;
     AVFormatContext *avf;
     char *format;              ///< format to use for output segment files
@@ -121,6 +123,8 @@ typedef struct SegmentContext {
     int   break_non_keyframes;
     int   write_empty;
 
+    int64_t duration_ts;
+
     int use_rename;
     char temp_list_filename[1024];
 
@@ -164,6 +168,7 @@ static int segment_mux_init(AVFormatContext *s)
     oc->io_close2          = s->io_close2;
     oc->io_open            = s->io_open;
     oc->flags              = s->flags;
+    oc->strict_std_compliance = s->strict_std_compliance;
 
     for (i = 0; i < s->nb_streams; i++) {
         AVStream *st, *ist = s->streams[i];
@@ -241,6 +246,17 @@ static int segment_start(AVFormatContext *s, int write_header)
         if ((err = segment_mux_init(s)) < 0)
             return err;
         oc = seg->avf;
+#if 0
+        /* I added this to have contiguous PTS of an stream but we might not need to go this direction (RM) */
+        if (!seg->reset_timestamps)
+            oc->avoid_negative_ts = AVFMT_AVOID_NEG_TS_MAKE_NON_NEGATIVE;
+#endif
+    }
+
+    // Initialize segment_start_index
+    if (!seg->segment_start_index_initialized) {
+        seg->segment_start_index = seg->segment_idx;
+        seg->segment_start_index_initialized = 1;
     }
 
     seg->segment_idx++;
@@ -250,6 +266,7 @@ static int segment_start(AVFormatContext *s, int write_header)
     if ((err = set_segment_filename(s)) < 0)
         return err;
 
+    oc->avpipe_opaque = s->avpipe_opaque;
     if ((err = s->io_open(s, &oc->pb, oc->url, AVIO_FLAG_WRITE, NULL)) < 0) {
         av_log(s, AV_LOG_ERROR, "Failed to open segment '%s'\n", oc->url);
         return err;
@@ -765,6 +782,7 @@ static int seg_init(AVFormatContext *s)
     if ((ret = set_segment_filename(s)) < 0)
         return ret;
     oc = seg->avf;
+    oc->avpipe_opaque = s->avpipe_opaque;
 
     if (seg->write_header_trailer) {
         if ((ret = s->io_open(s, &oc->pb,
@@ -856,6 +874,7 @@ static int seg_write_packet(AVFormatContext *s, AVPacket *pkt)
     struct tm ti;
     int64_t usecs;
     int64_t wrapped_val;
+    int check_pts = 0;
 
     if (!seg->avf || !seg->avf->pb)
         return AVERROR(EINVAL);
@@ -916,14 +935,28 @@ calc_times:
     if (pkt->pts != AV_NOPTS_VALUE)
         pkt_pts_avtb = av_rescale_q(pkt->pts, st->time_base, AV_TIME_BASE_Q);
 
+    /* If duration_ts was set use it to cut the segment, otherwise use the original time comparison of ffmpeg*/
+    if (seg->duration_ts > 0)
+        check_pts = (pkt->pts >= (seg->cur_entry.index + 1 - seg->segment_start_index) * seg->duration_ts);
+    else
+        check_pts = pkt_pts_avtb - seg->cur_entry.start_pts >= seg->min_seg_duration &&
+                    av_compare_ts(pkt->pts, st->time_base, end_pts - seg->time_delta, AV_TIME_BASE_Q) >= 0;
+
+#if 0
+    av_log(s, AV_LOG_INFO, "FFF packet stream:%d pts:%s pts_time:%s duration_time:%s is_key:%d frame:%d, check_pts=%d\n",
+            pkt->stream_index, av_ts2str(pkt->pts), av_ts2timestr(pkt->pts, &st->time_base),
+            av_ts2timestr(pkt->duration, &st->time_base),
+            pkt->flags & AV_PKT_FLAG_KEY,
+            pkt->stream_index == seg->reference_stream_index ? seg->frame_count : -1,
+            check_pts);
+#endif
+
     if (pkt->stream_index == seg->reference_stream_index &&
         (pkt->flags & AV_PKT_FLAG_KEY || seg->break_non_keyframes) &&
         (seg->segment_frame_count > 0 || seg->write_empty) &&
         (seg->cut_pending || seg->frame_count >= start_frame ||
-         (pkt->pts != AV_NOPTS_VALUE &&
-          pkt_pts_avtb - seg->cur_entry.start_pts >= seg->min_seg_duration &&
-          av_compare_ts(pkt->pts, st->time_base,
-                        end_pts - seg->time_delta, AV_TIME_BASE_Q) >= 0))) {
+        (pkt->pts != AV_NOPTS_VALUE && check_pts))) {
+
         /* sanitize end time in case last packet didn't have a defined duration */
         if (seg->cur_entry.last_duration == 0)
             seg->cur_entry.end_time = (double)pkt->pts * av_q2d(st->time_base);
@@ -938,6 +971,17 @@ calc_times:
         seg->cur_entry.index = seg->segment_idx + seg->segment_idx_wrap * seg->segment_idx_wrap_nb;
         seg->cur_entry.start_time = (double)pkt->pts * av_q2d(st->time_base);
         seg->cur_entry.start_pts = av_rescale_q(pkt->pts, st->time_base, AV_TIME_BASE_Q);
+
+        av_log(s, AV_LOG_INFO, "segment eos stream:%d segment:%d pts:%s pts_time:%s duration_time:%s is_key:%d frame:%d "
+            "end_pts=%"PRId64" tdelta=%"PRId64" initoff=%"PRId64", rescale=%"PRId64", st->start_time=%"PRId64", cur_seg->start_time=%f\n",
+            pkt->stream_index, seg->cur_entry.index, av_ts2str(pkt->pts), av_ts2timestr(pkt->pts, &st->time_base),
+            av_ts2timestr(pkt->duration, &st->time_base),
+            pkt->flags & AV_PKT_FLAG_KEY,
+            pkt->stream_index == seg->reference_stream_index ? seg->frame_count : -1,
+            end_pts, seg->time_delta, seg->initial_offset,
+            av_rescale_q(pkt->pts, st->time_base, AV_TIME_BASE_Q),
+            st->start_time, seg->cur_entry.start_time);
+
         seg->cur_entry.end_time = seg->cur_entry.start_time;
 
         if (seg->times || (!seg->frames && !seg->use_clocktime) && seg->write_empty)
@@ -952,7 +996,7 @@ calc_times:
     }
 
     if (seg->segment_frame_count == 0) {
-        av_log(s, AV_LOG_VERBOSE, "segment:'%s' starts with packet stream:%d pts:%s pts_time:%s frame:%d\n",
+        av_log(s, AV_LOG_INFO, "segment:'%s' starts with packet stream:%d pts:%s pts_time:%s frame:%d\n",
                seg->avf->url, pkt->stream_index,
                av_ts2str(pkt->pts), av_ts2timestr(pkt->pts, &st->time_base), seg->frame_count);
     }
@@ -966,6 +1010,10 @@ calc_times:
     /* compute new timestamps */
     offset = av_rescale_q(seg->initial_offset - (seg->reset_timestamps ? seg->cur_entry.start_pts : 0),
                           AV_TIME_BASE_Q, st->time_base);
+
+    av_log(s, AV_LOG_DEBUG, "offset=%"PRId64", reset_timestamps=%d, cur_entry.start_pts=%"PRId64", initial_offset=%"PRId64", pkt->pts=%"PRId64,
+        offset, seg->reset_timestamps, seg->cur_entry.start_pts, seg->initial_offset, pkt->pts);
+
     if (pkt->pts != AV_NOPTS_VALUE)
         pkt->pts += offset;
     if (pkt->dts != AV_NOPTS_VALUE)
@@ -1075,6 +1123,7 @@ static const AVOption options[] = {
     { "reset_timestamps", "reset timestamps at the beginning of each segment", OFFSET(reset_timestamps), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, E },
     { "initial_offset", "set initial timestamp offset", OFFSET(initial_offset), AV_OPT_TYPE_DURATION, {.i64 = 0}, -INT64_MAX, INT64_MAX, E },
     { "write_empty_segments", "allow writing empty 'filler' segments", OFFSET(write_empty), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, E },
+    { "segment_duration_ts", "set segment duration based on timebase",        OFFSET(duration_ts), AV_OPT_TYPE_INT64, {.i64 = 0}, 0, 86400000000LL, E},
     { NULL },
 };
 

--- a/libavformat/utils.c
+++ b/libavformat/utils.c
@@ -341,7 +341,7 @@ static int get_frame_filename(char *buf, int buf_size, const char *path, int64_t
     return ff_bprint_get_frame_filename(&bp, path, number, flags) < 0 ? -1 : 0;
 }
 
-int av_get_frame_filename2(char *buf, int buf_size, const char *path, int number, int flags)
+int av_get_frame_filename2(char *buf, int buf_size, const char *path, int64_t number, int flags)
 {
     return get_frame_filename(buf, buf_size, path, number, flags);
 }


### PR DESCRIPTION

- Add avpipe_opaque to AVFormatContext for external I/O handler context
- Add frame duration tracking fields for adaptive segment boundary detection
- Widen av_get_frame_filename2 number param from int to int64_t for PTS filenames
- Add segment_duration_ts option for PTS-based cutting in segment muxer
- Propagate avpipe_opaque and strict_std_compliance to sub-muxers
- Add seg_duration_ts, start_segment, start_fragment_index options to DASH muxer
- Replace av_compare_ts with tolerant PTS comparison using frame_duration_variation
- Force use_rename=0 for non-file protocols, guard SIGFPE on total_duration==0
- Add frag_discont movflag when start_segment > 1
- Add io_open fallback in MOV muxer for non-file output protocols