### PR TITLE
ELUVIO - fix DASH segment generation when mez source has bframes.

### DIFF
--- a/libavformat/dashenc.c
+++ b/libavformat/dashenc.c
@@ -227,6 +227,7 @@ typedef struct DASHContext {
 
     int64_t seg_duration_ts;
     int64_t start_fragment_index;
+    int avpipe_bypass_bframes;
 
     // Pass-through options to movenc -PTT
     char *encryption_scheme_str;
@@ -1867,10 +1868,14 @@ static int dash_init(AVFormatContext *s)
                  * Setting 'use_editlist=0' causes movenc to pass through the source DTS/PTS and just adjust
                  * segment number and start pts.
                  */
-                if (c->start_segment > 1 &&
-                    st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO &&
-                    st->codecpar->video_delay > 0) {
+                if (c->avpipe_bypass_bframes &&
+                    c->start_segment > 1 &&
+                    st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
+                    av_log(s, AV_LOG_INFO, "ELUVIO avpipe bypass bframes = 1 setting use_editlist=0\n");
                     av_dict_set(&opts, "use_editlist", "0", 0);
+                } else if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
+                    av_log(s, AV_LOG_INFO, "ELUVIO avpipe bypass bframes = %d not setting use_editlist=0\n",
+                           c->avpipe_bypass_bframes);
                 }
             }
 
@@ -2529,10 +2534,15 @@ static int dash_write_packet(AVFormatContext *s, AVPacket *pkt)
          * When source MP4 has bframes, deriving the first PTS of next segment is incorrect.
          */
         if (os->segment_type == SEGMENT_TYPE_MP4 &&
-            st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO &&
-            st->codecpar->video_delay > 0 &&
-            (ret = av_opt_set(os->ctx->priv_data, "movflags", "+frag_discont", 0)) < 0)
-            return ret;
+            st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
+            if (c->avpipe_bypass_bframes) {
+                av_log(s, AV_LOG_INFO, "ELUVIO avpipe bypass bframes = 1 setting frag_discont after flush\n");
+                if ((ret = av_opt_set(os->ctx->priv_data, "movflags", "+frag_discont", 0)) < 0)
+                    return ret;
+            } else {
+                av_log(s, AV_LOG_INFO, "ELUVIO avpipe bypass bframes = 0 not setting frag_discont after flush\n");
+            }
+        }
     }
 
     if (!os->packets_written) {
@@ -2759,6 +2769,7 @@ static const AVOption options[] = {
     { "seg_duration_ts", "segment duration timebase", OFFSET(seg_duration_ts), AV_OPT_TYPE_INT64, { .i64 = 48048 }, 0, INT64_MAX, E },
     { "start_fragment_index", "starting frame sequence for fragmented mp4", OFFSET(start_fragment_index), AV_OPT_TYPE_INT64, { .i64 = 0 }, 0, INT64_MAX, E },
     { "start_segment", "Specify the index of the first segment (which by default is 1)", OFFSET(start_segment), AV_OPT_TYPE_INT, { .i64 = 1 }, 0, INT_MAX, E },
+    { "avpipe_bypass_bframes", "Preserve avpipe bypass timestamps for video with B-frame reordering", OFFSET(avpipe_bypass_bframes), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, E },
     { "encryption_scheme", "Configures the Common Encryption scheme, allowed values are none, cenc-aes-ctr, cenc-aes-cbc-pattern", OFFSET(encryption_scheme_str), AV_OPT_TYPE_STRING, {.str = NULL}, .flags = AV_OPT_FLAG_ENCODING_PARAM },
     { "encryption_key", "The media encryption key (hex)", OFFSET(encryption_key), AV_OPT_TYPE_STRING, {.str = NULL}, .flags = AV_OPT_FLAG_ENCODING_PARAM },
     { "encryption_kid", "The media encryption key identifier (hex)", OFFSET(encryption_kid), AV_OPT_TYPE_STRING, {.str = NULL}, .flags = AV_OPT_FLAG_ENCODING_PARAM },

--- a/libavformat/dashenc.c
+++ b/libavformat/dashenc.c
@@ -1867,7 +1867,9 @@ static int dash_init(AVFormatContext *s)
                  * Setting 'use_editlist=0' causes movenc to pass through the source DTS/PTS and just adjust
                  * segment number and start pts.
                  */
-                if (c->start_segment > 1) {
+                if (c->start_segment > 1 &&
+                    st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO &&
+                    st->codecpar->video_delay > 0) {
                     av_dict_set(&opts, "use_editlist", "0", 0);
                 }
             }
@@ -2527,6 +2529,8 @@ static int dash_write_packet(AVFormatContext *s, AVPacket *pkt)
          * When source MP4 has bframes, deriving the first PTS of next segment is incorrect.
          */
         if (os->segment_type == SEGMENT_TYPE_MP4 &&
+            st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO &&
+            st->codecpar->video_delay > 0 &&
             (ret = av_opt_set(os->ctx->priv_data, "movflags", "+frag_discont", 0)) < 0)
             return ret;
     }

--- a/libavformat/dashenc.c
+++ b/libavformat/dashenc.c
@@ -1871,12 +1871,8 @@ static int dash_init(AVFormatContext *s)
                 if (c->avpipe_bypass_bframes &&
                     c->start_segment > 1 &&
                     st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
-                    av_log(s, AV_LOG_INFO, "ELUVIO avpipe bypass bframes = 1 setting use_editlist=0\n");
                     av_dict_set(&opts, "use_editlist", "0", 0);
                     ctx->avoid_negative_ts = AVFMT_AVOID_NEG_TS_DISABLED;
-                } else if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
-                    av_log(s, AV_LOG_INFO, "ELUVIO avpipe bypass bframes = %d not setting use_editlist=0\n",
-                           c->avpipe_bypass_bframes);
                 }
             }
 
@@ -2534,15 +2530,11 @@ static int dash_write_packet(AVFormatContext *s, AVPacket *pkt)
         /* ELUVIO - Mark the next MP4 fragment discontinuous so movenc preserves the incoming packet PTS.
          * When source MP4 has bframes, deriving the first PTS of next segment is incorrect.
          */
-        if (os->segment_type == SEGMENT_TYPE_MP4 &&
+        if (c->avpipe_bypass_bframes &&
+            os->segment_type == SEGMENT_TYPE_MP4 &&
             st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
-            if (c->avpipe_bypass_bframes) {
-                av_log(s, AV_LOG_INFO, "ELUVIO avpipe bypass bframes = 1 setting frag_discont after flush\n");
-                if ((ret = av_opt_set(os->ctx->priv_data, "movflags", "+frag_discont", 0)) < 0)
-                    return ret;
-            } else {
-                av_log(s, AV_LOG_INFO, "ELUVIO avpipe bypass bframes = 0 not setting frag_discont after flush\n");
-            }
+            if ((ret = av_opt_set(os->ctx->priv_data, "movflags", "+frag_discont", 0)) < 0)
+                return ret;
         }
     }
 

--- a/libavformat/dashenc.c
+++ b/libavformat/dashenc.c
@@ -1873,6 +1873,7 @@ static int dash_init(AVFormatContext *s)
                     st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
                     av_log(s, AV_LOG_INFO, "ELUVIO avpipe bypass bframes = 1 setting use_editlist=0\n");
                     av_dict_set(&opts, "use_editlist", "0", 0);
+                    ctx->avoid_negative_ts = AVFMT_AVOID_NEG_TS_DISABLED;
                 } else if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
                     av_log(s, AV_LOG_INFO, "ELUVIO avpipe bypass bframes = %d not setting use_editlist=0\n",
                            c->avpipe_bypass_bframes);

--- a/libavformat/dashenc.c
+++ b/libavformat/dashenc.c
@@ -1862,6 +1862,14 @@ static int dash_init(AVFormatContext *s)
                         av_dict_set(&opts, "movflags", "frag_every_frame+dash+delay_moov", 0);
                     }
                 }
+                /* ELUVIO - for DASH segments with start_segment > 1 (mez part 2 onward) and source mez with bframes and
+                 * CTS > 0 (eg. first frame DTS=0 PTS=1536) movenc shifts tfdt PTS by the first CTS offset.
+                 * Setting 'use_editlist=0' causes movenc to pass through the source DTS/PTS and just adjust
+                 * segment number and start pts.
+                 */
+                if (c->start_segment > 1) {
+                    av_dict_set(&opts, "use_editlist", "0", 0);
+                }
             }
 
             if (c->start_fragment_index > 1) {
@@ -2516,7 +2524,7 @@ static int dash_write_packet(AVFormatContext *s, AVPacket *pkt)
             return ret;
 
         /* ELUVIO - Mark the next MP4 fragment discontinuous so movenc preserves the incoming packet PTS.
-         * When source MP4 has bframes, deriving the first PTS of next fragment is incorrect.
+         * When source MP4 has bframes, deriving the first PTS of next segment is incorrect.
          */
         if (os->segment_type == SEGMENT_TYPE_MP4 &&
             (ret = av_opt_set(os->ctx->priv_data, "movflags", "+frag_discont", 0)) < 0)

--- a/libavformat/dashenc.c
+++ b/libavformat/dashenc.c
@@ -2514,6 +2514,13 @@ static int dash_write_packet(AVFormatContext *s, AVPacket *pkt)
 
         if ((ret = dash_flush(s, 0, pkt->stream_index)) < 0)
             return ret;
+
+        /* ELUVIO - Mark the next MP4 fragment discontinuous so movenc preserves the incoming packet PTS.
+         * When source MP4 has bframes, deriving the first PTS of next fragment is incorrect.
+         */
+        if (os->segment_type == SEGMENT_TYPE_MP4 &&
+            (ret = av_opt_set(os->ctx->priv_data, "movflags", "+frag_discont", 0)) < 0)
+            return ret;
     }
 
     if (!os->packets_written) {


### PR DESCRIPTION
- mark next fragment 'discontinuous' using +frag_discont
- this instructs the muxer to use the PTS of the incoming packet instead of derriving it from the previous fragments DTS

The fix is non-intuitive because 'frag_discont' is used to indicate that the next fragment is not continuous to the previous one.

The reason it works for us is becuase:
(a) The source mez part already has contiguous DTS/PTS
(b) The implementation of movenc ff_mov_write_packet() simply uses the source DTS/PTS when using 'frag_discount' which happens to be exactly what we want:

The bug comes from `movenc.c` `ff_mov_write_packet()`

```
       if (!trk->frag_discont) {
            /* First packet of a new fragment. We already wrote the duration
             * of the last packet of the previous fragment based on track_duration,
             * which might not exactly match our dts. Therefore adjust the dts
             * of this packet to be what the previous packets duration implies. */
            trk->cluster[trk->entry].dts = trk->start_dts + trk->track_duration;
            /* We also may have written the pts and the corresponding duration
             * in sidx/tfrf/tfxd tags; make sure the sidx pts and duration match up with
             * the next fragment. This means the cts of the first sample must
             * be the same in all fragments, unless end_pts was updated by
             * the packet causing the fragment to be written. */
            if ((mov->flags & FF_MOV_FLAG_DASH &&
                !(mov->flags & (FF_MOV_FLAG_GLOBAL_SIDX | FF_MOV_FLAG_SKIP_SIDX))) ||
                mov->mode == MODE_ISM)
                pkt->pts = pkt->dts + trk->end_pts - trk->cluster[trk->entry].dts;         <===== this makes the wrong PTS.  In our case is the PTS of another frame in the previous DASH segment
        } else {
            /* New fragment, but discontinuous from previous fragments.
             * Pretend the duration sum of the earlier fragments is
             * pkt->dts - trk->start_dts. */
            trk->end_pts = AV_NOPTS_VALUE;
            trk->frag_discont = 0;
        }
```

This is the evidence of the bad PTS:

```
source/output DTS/PTS comparison
source max B-frame composition offset: 5120 ticks (10.00 frames) at source decode_frame=1
source max decode/presentation displacement: 7 frames at source decode_frame=1 presentation_frame=8 dts=512 pts=5632
 frame  type      source dts/pts      output dts/pts  output   diff
     0     I              0/1536              0/1536  new seg  -
     1     B            512/5632            512/5632           -
     2     B           1024/3584           1024/3584           -
     3     B           1536/2560           1536/2560           -
     4     B           2048/2048           2048/2048           -
     5     B           2560/3072           2560/3072           -
     6     B           3072/4608           3072/4608           -
     7     B           3584/4096           3584/4096           -
     8     B           4096/5120           4096/5120           -
     9     B           4608/9728           4608/9728           -
    10     B           5120/7680           5120/7680           -
    11     B           5632/6656           5632/6656           -
    12     B           6144/6144           6144/6144           -
    13     B           6656/7168           6656/7168           -
    14     B           7168/8704           7168/8704           -
    15     B           7680/8192           7680/8192           -
    16     B           8192/9216           8192/9216           -
    17     B          8704/13824          8704/13824           -
    18     B          9216/11776          9216/11776           -
    19     B          9728/10752          9728/10752           -
    20     B         10240/10240         10240/10240           -
    21     B         10752/11264         10752/11264           -
    22     B         11264/12800         11264/12800           -
    23     B         11776/12288         11776/12288           -
    24     B         12288/13312         12288/13312           -
    25     B         12800/14848         12800/14848           -
    26     B         13312/14336         13312/14336           -
    27     I         13824/15360         13824/15360           -
    28     B         14336/19456         14336/19456           -
    29     B         14848/17408         14848/17408           -
    30     B         15360/16384         15360/16384           -
    31     B         15872/15872         15872/15872           -
    32     B         16384/16896         16384/16896           -
    33     B         16896/18432         16896/18432           -
    34     B         17408/17920         17408/17920           -
    35     B         17920/18944         17920/18944           -
    36     I         18432/19968         18432/19968           -
    37     B         18944/24064         18944/24064           -
    38     B         19456/22016         19456/22016           -
    39     B         19968/20992         19968/20992           -
    40     B         20480/20480         20480/20480           -
    41     B         20992/21504         20992/21504           -
    42     B         21504/23040         21504/23040           -
    43     B         22016/22528         22016/22528           -
    44     B         22528/23552         22528/23552           -
    45     B         23040/25600         23040/25600           -
    46     B         23552/25088         23552/25088           -
    47     B         24064/24576         24064/24576           -
    48     I         24576/26112         24576/25088  new seg  PTS
    49     B         25088/30208         25088/30208           -
    50     B         25600/28160         25600/28160           -
    51     B         26112/27136         26112/27136           -
    52     B         26624/26624         26624/26624           -
    53     B         27136/27648         27136/27648           -
    54     B         27648/29184         27648/29184           -
    55     B         28160/28672         28160/28672           -
    56     B         28672/29696         28672/29696           -
    57     B         29184/34304         29184/34304           -
    58     B         29696/32256         29696/32256           -
    59     B         30208/31232         30208/31232           -
    60     B         30720/30720         30720/30720           -
    61     B         31232/31744         31232/31744           -
    62     B         31744/33280         31744/33280           -
    63     B         32256/32768         32256/32768           -
    64     B         32768/33792         32768/33792           -
    65     B         33280/38400         33280/38400           -
    66     B         33792/36352         33792/36352           -
    67     B         34304/35328         34304/35328           -
    68     B         34816/34816         34816/34816           -
    69     B         35328/35840         35328/35840           -
    70     B         35840/37376         35840/37376           -
    71     B         36352/36864         36352/36864           -
    72     B         36864/37888         36864/37888           -
    73     B         37376/42496         37376/42496           -
    74     B         37888/40448         37888/40448           -
    75     B         38400/39424         38400/39424           -
    76     B         38912/38912         38912/38912           -
    77     B         39424/39936         39424/39936           -
    78     B         39936/41472         39936/41472           -
    79     B         40448/40960         40448/40960           -
    80     B         40960/41984         40960/41984           -
    81     B         41472/46592         41472/46592           -
    82     B         41984/44544         41984/44544           -
    83     B         42496/43520         42496/43520           -
    84     B         43008/43008         43008/43008           -
    85     B         43520/44032         43520/44032           -
    86     B         44032/45568         44032/45568           -
    87     B         44544/45056         44544/45056           -
    88     B         45056/46080         45056/46080           -
    89     B         45568/50176         45568/50176           -
    90     B         46080/48640         46080/48640           -
    91     B         46592/47616         46592/47616           -
    92     B         47104/47104         47104/47104           -
    93     B         47616/48128         47616/48128           -
    94     B         48128/49664         48128/49664           -
    95     B         48640/49152         48640/49152           -
    96     I         49152/50688         49152/49664  new seg  PTS
    97     B         49664/54784         49664/54784           -
    98     B         50176/52736         50176/52736           -

```


